### PR TITLE
🔀 병합 : MongoDB 다큐먼트 감사 필드 추가

### DIFF
--- a/src/main/java/darkoverload/itzip/ItzipApplication.java
+++ b/src/main/java/darkoverload/itzip/ItzipApplication.java
@@ -3,8 +3,10 @@ package darkoverload.itzip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableMongoAuditing
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
+++ b/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -11,8 +12,8 @@ import java.time.LocalDateTime;
 /**
  * create, modify date 추상 클래스
  */
-@ToString
 @Getter
+@ToString
 public abstract class MongoAuditingFields {
 
     /**
@@ -20,6 +21,7 @@ public abstract class MongoAuditingFields {
      */
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
+    @Field("create_date")
     protected LocalDateTime createDate;
 
     /**
@@ -27,5 +29,6 @@ public abstract class MongoAuditingFields {
      */
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
+    @Field("modify_date")
     protected LocalDateTime modifyDate;
 }

--- a/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
+++ b/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
@@ -1,0 +1,31 @@
+package darkoverload.itzip.global.entity;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+/**
+ * create, modify date 추상 클래스
+ */
+@ToString
+@Getter
+public abstract class MongoAuditingFields {
+
+    /**
+     * create_date 엔티티 생성 시 자동 생성, 수정 불가
+     */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    protected LocalDateTime createDate;
+
+    /**
+     * modify_date 엔티티 수정 시 자동 업데이트
+     */
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    protected LocalDateTime modifyDate;
+}

--- a/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
+++ b/src/main/java/darkoverload/itzip/global/entity/MongoAuditingFields.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public abstract class MongoAuditingFields {
 
     /**
-     * create_date 엔티티 생성 시 자동 생성, 수정 불가
+     * 다큐먼트 생성 시 create_date 자동 생성 및 수정 불가
      */
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
@@ -25,7 +25,7 @@ public abstract class MongoAuditingFields {
     protected LocalDateTime createDate;
 
     /**
-     * modify_date 엔티티 수정 시 자동 업데이트
+     * 다큐먼트 수정 시 modify_date 자동 업데이트
      */
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate


### PR DESCRIPTION
### 병합 내역

- MongoAuditingFields : MongoDB 문서의 생성 및 수정 타임스탬프를 자동으로 기록하고 관리하기 위한 감사 필드 클래스

- @EnableMongoAuditing : MongoDB의 감사 기능을 활성화하기 위한 어노테이션

Ref : #35, #45