### PR TITLE
🛠️ 리팩토링 : 메일 발송 로직 리팩토링 #87

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -199,7 +199,7 @@ public class UserController {
     @PostMapping("/authEmail")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations(CommonExceptionCode.FILED_ERROR)
-    public ResponseEntity<String> sendAuthEmail(@RequestBody @Valid EmailSendRequest emailSendDto, BindingResult bindingResult) {
+    public ResponseEntity<String> sendAuthEmail(@RequestBody @Valid EmailSendRequest emailSendRequest, BindingResult bindingResult) {
         // 필드 에러 확인
         if (bindingResult.hasErrors()) {
             throw new RestApiException(CommonExceptionCode.FILED_ERROR);
@@ -207,10 +207,15 @@ public class UserController {
 
         // 랜덤 인증 코드 생성
         String authCode = RandomAuthCode.generate();
+
         // redis에 인증 코드 저장
-        verificationService.saveCode(emailSendDto.getEmail(), authCode);
+        verificationService.saveCode(emailSendRequest.getEmail(), authCode);
+
+        // 메일 제목
+        String subject = "[ITZIP] 이메일 인증번호 : " + authCode;
+
         // 메일 발송
-        emailService.sendSimpleMessage(emailSendDto.getEmail(), "test", authCode);
+        emailService.sendSimpleMessage(emailSendRequest.getEmail(), subject, authCode);
         return ResponseEntity.ok("인증 메일이 발송되었습니다.");
     }
 

--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -10,10 +10,8 @@ import darkoverload.itzip.feature.user.controller.request.UserLoginRequest;
 import darkoverload.itzip.feature.user.controller.response.UserLoginResponse;
 import darkoverload.itzip.feature.user.domain.User;
 import darkoverload.itzip.feature.user.entity.Authority;
-import darkoverload.itzip.feature.user.service.EmailService;
 import darkoverload.itzip.feature.user.service.UserService;
 import darkoverload.itzip.feature.user.service.VerificationService;
-import darkoverload.itzip.feature.user.util.RandomAuthCode;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.code.CommonResponseCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
@@ -39,7 +37,6 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
     private final UserService userService;
     private final TokenService tokenService;
-    private final EmailService emailService;
     private final VerificationService verificationService;
 
     private final PasswordEncoder passwordEncoder;
@@ -200,23 +197,7 @@ public class UserController {
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations(CommonExceptionCode.FILED_ERROR)
     public ResponseEntity<String> sendAuthEmail(@RequestBody @Valid EmailSendRequest emailSendRequest, BindingResult bindingResult) {
-        // 필드 에러 확인
-        if (bindingResult.hasErrors()) {
-            throw new RestApiException(CommonExceptionCode.FILED_ERROR);
-        }
-
-        // 랜덤 인증 코드 생성
-        String authCode = RandomAuthCode.generate();
-
-        // redis에 인증 코드 저장
-        verificationService.saveCode(emailSendRequest.getEmail(), authCode);
-
-        // 메일 제목
-        String subject = "[ITZIP] 이메일 인증번호 : " + authCode;
-
-        // 메일 발송
-        emailService.sendSimpleMessage(emailSendRequest.getEmail(), subject, authCode);
-        return ResponseEntity.ok("인증 메일이 발송되었습니다.");
+        return userService.sendAuthEmail(emailSendRequest, bindingResult);
     }
 
     /**

--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -18,6 +18,8 @@ import darkoverload.itzip.global.config.response.exception.RestApiException;
 import darkoverload.itzip.global.config.swagger.ExceptionCodeAnnotations;
 import darkoverload.itzip.global.config.swagger.ResponseCodeAnnotation;
 import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +32,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User", description = "회원 기능 API")
 @RestController
 @RequestMapping("/user")
 @Slf4j
@@ -193,6 +196,10 @@ public class UserController {
     /**
      * 인증번호 발송 메소드
      */
+    @Operation(
+            summary = "인증메일 발송",
+            description = "회원가입 시 인증메일을 발송합니다."
+    )
     @PostMapping("/authEmail")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations(CommonExceptionCode.FILED_ERROR)

--- a/src/main/java/darkoverload/itzip/feature/user/controller/request/EmailSendRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/request/EmailSendRequest.java
@@ -4,19 +4,17 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * 이메일 발송 dto
  */
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class EmailSendRequest {
     @NotEmpty(message = "이메일을 입력해주세요.")
     @Pattern(regexp = "^[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$",
             message = "올바르지 않은 이메일 형식입니다.")
     private String email;
-
-    private String subject;
-
-    private String text;
 }

--- a/src/main/java/darkoverload/itzip/feature/user/controller/request/EmailSendRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/request/EmailSendRequest.java
@@ -1,5 +1,6 @@
 package darkoverload.itzip.feature.user.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -16,5 +17,6 @@ public class EmailSendRequest {
     @NotEmpty(message = "이메일을 입력해주세요.")
     @Pattern(regexp = "^[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$",
             message = "올바르지 않은 이메일 형식입니다.")
+    @Schema(description = "이메일", example = "example@gmail.com")
     private String email;
 }

--- a/src/main/java/darkoverload/itzip/feature/user/service/EmailService.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/EmailService.java
@@ -1,5 +1,9 @@
 package darkoverload.itzip.feature.user.service;
 
 public interface EmailService {
-    void sendSimpleMessage(String to, String subject, String text);
+    void sendSimpleMail(String to, String subject, String text);
+
+    void sendFormMail(String to, String subject, String body);
+
+    String setAuthForm(String authCode);
 }

--- a/src/main/java/darkoverload/itzip/feature/user/service/EmailServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/EmailServiceImpl.java
@@ -1,6 +1,7 @@
 package darkoverload.itzip.feature.user.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,9 @@ public class EmailServiceImpl implements EmailService {
     @Autowired
     private JavaMailSender mailSender;
 
+    @Value("${LOC_GMAIL_USERNAME}")
+    private String fromEmail;
+
     /**
      * 간단한 이메일 메시지를 보내는 메소드
      *
@@ -22,6 +26,7 @@ public class EmailServiceImpl implements EmailService {
     public void sendSimpleMessage(String to, String subject, String text) {
         // SimpleMailMessage 객체 생성 및 설정
         SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(String.format("ITZIP <%s>", fromEmail)); // 수신자 설정
         message.setTo(to); // 수신자 설정
         message.setSubject(subject); // 제목 설정
         message.setText(text); // 본문 설정

--- a/src/main/java/darkoverload/itzip/feature/user/service/EmailServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/EmailServiceImpl.java
@@ -1,10 +1,18 @@
 package darkoverload.itzip.feature.user.service;
 
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Service
 public class EmailServiceImpl implements EmailService {
@@ -13,17 +21,17 @@ public class EmailServiceImpl implements EmailService {
     @Autowired
     private JavaMailSender mailSender;
 
-    @Value("${LOC_GMAIL_USERNAME}")
+    @Value("${spring.mail.username}")
     private String fromEmail;
 
     /**
      * 간단한 이메일 메시지를 보내는 메소드
      *
-     * @param to 수신자 이메일 주소
+     * @param to      수신자 이메일 주소
      * @param subject 이메일 제목
-     * @param text 이메일 본문
+     * @param text    이메일 본문
      */
-    public void sendSimpleMessage(String to, String subject, String text) {
+    public void sendSimpleMail(String to, String subject, String text) {
         // SimpleMailMessage 객체 생성 및 설정
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom(String.format("ITZIP <%s>", fromEmail)); // 수신자 설정
@@ -33,4 +41,50 @@ public class EmailServiceImpl implements EmailService {
         // 이메일 전송
         mailSender.send(message);
     }
+
+    /**
+     * html 폼 메일을 발송하는 메소드
+     *
+     * @param to      수신자 이메일 주소
+     * @param subject 이메일 제목
+     * @param body    이메일 본문(html)
+     */
+    public void sendFormMail(String to, String subject, String body) {
+        MimeMessage message = mailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+            messageHelper.setSubject(subject);
+            messageHelper.setTo(to);
+            messageHelper.setFrom(fromEmail, "ITZIP");
+            messageHelper.setText(body, true);
+            mailSender.send(message);
+        } catch (Exception e) {
+            throw new RestApiException(CommonExceptionCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 인증메일 폼에 인증코드를 추가하여 반환하는 메소드
+     * @param authcode 인증코드
+     * @return 인증코드를 추가한 인증메일 폼
+     */
+    public String setAuthForm(String authcode) {
+        // 인증메일 폼 경로 설정
+        String templatePath = "src/main/resources/templates/authMailForm.html";
+
+        // 인증메일 폼 읽어오기
+        String htmlContent = null;
+        try {
+            htmlContent = new String(Files.readAllBytes(Paths.get(templatePath)));
+        } catch (IOException e) {
+            throw new RestApiException(CommonExceptionCode.INTERNAL_SERVER_ERROR);
+        }
+
+        // {{authcode}}를 실제 인증 코드로 대체
+        htmlContent = htmlContent.replace("{{authcode}}", authcode);
+
+        return htmlContent;
+    }
+
 }

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
@@ -1,7 +1,10 @@
 package darkoverload.itzip.feature.user.service;
 
+import darkoverload.itzip.feature.user.controller.request.EmailSendRequest;
 import darkoverload.itzip.feature.user.controller.request.UserJoinRequest;
 import darkoverload.itzip.feature.user.domain.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 
 import java.util.Optional;
 
@@ -15,4 +18,6 @@ public interface UserService {
     Optional<User> findById(Long id);
 
     Optional<User> findByNickname(String nickname);
+
+    ResponseEntity<String> sendAuthEmail(EmailSendRequest emailSendRequest, BindingResult bindingResult);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,8 +26,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${LOC_GAMIL_USERNAME}
-    password: ${LOC_GAMIL_PASSWORD}
+    username: ${LOC_GMAIL_USERNAME}
+    password: ${LOC_GMAIL_PASSWORD}
     properties:
       mail:
         smtp:

--- a/src/main/resources/templates/authMailForm.html
+++ b/src/main/resources/templates/authMailForm.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ITZIP 인증번호</title>
+</head>
+<body style="background-color: #F5F5F5; color: #333333; margin: 0; padding: 0;">
+<div style="max-width: 600px; margin: 0 auto; background-color: #FFFFFF; padding: 20px; border: 1px solid #E0E0E0; border-radius: 8px;">
+    <div style="text-align: center; margin-bottom: 20px;">
+        <img src="https://dy1vg9emkijkn.cloudfront.net/static/itzip_logo_white.png" alt="ITZIP Logo"
+             style="width: 120px;">
+    </div>
+    <div style="background-color: #3B60E4; border-radius: 8px; padding: 20px; text-align: center; color: white;">
+        <h1 style="font-size: 24px; margin: 0;">인증번호</h1>
+        <p style="font-size: 16px; margin: 10px 0;">안녕하세요, ITZIP입니다.</p>
+        <p style="font-size: 16px; margin: 10px 0;">아래 인증번호를 입력하여 본인 인증을 완료하세요.</p>
+        <div style="display: inline-block; background-color: #FFFFFF; color: #3B60E4; padding: 10px 20px; font-size: 18px; letter-spacing: 2px; border-radius: 4px; margin-top: 20px;">
+            {{authcode}}
+        </div>
+    </div>
+    <div style="text-align: center; margin-top: 20px; font-size: 12px; color: #888888;">
+        <p>본 메일은 발신전용 메일로 회신되지 않습니다.</p>
+        <p>© 2024 ITZIP. All rights reserved.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/darkoverload/itzip/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/darkoverload/itzip/feature/user/controller/UserControllerTest.java
@@ -44,7 +44,7 @@ class UserControllerTest {
         // redis에 인증 코드 저장
         verificationService.saveCode(email, authCode);
         // 메일 발송
-        emailService.sendSimpleMessage(email, "test", authCode);
+        emailService.sendFormMail(email, "test", authCode);
 
         log.info("인증 메일이 발송되었습니다.");
         log.info("인증번호 : {}", authCode);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -43,8 +43,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${TEST_GAMIL_USERNAME}
-    password: ${TEST_GAMIL_PASSWORD}
+    username: ${TEST_GMAIL_USERNAME}
+    password: ${TEST_GMAIL_PASSWORD}
     properties:
       mail:
         smtp:


### PR DESCRIPTION
## 수정 후 인증 메일

<img width="959" alt="스크린샷 2024-08-28 오후 1 05 36" src="https://github.com/user-attachments/assets/61ce244f-cd78-4d84-bacc-f5e843cdc851">

---

## 작업내용

1. 불필요한 request field 삭제
2. 환경변수 오타 수정
3. swagger 어노테이션 추가
4. 인증메일 폼 추가
    - 임시로 뷰 만들어서 적용했습니다. 추후 디자인 / 퍼블리싱 예정
5. 메일 발송자, 메일 제목 수정

Resolves: #87 