### PR TITLE
🐛	버그 수정 : swagger 커스텀 어노테이션

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/algorithm/domain/Problem.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/domain/Problem.java
@@ -1,0 +1,30 @@
+package darkoverload.itzip.feature.algorithm.domain;
+
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Problem {
+    private Long problemId;
+    private String title;
+    private Integer level;
+    private Integer acceptedUserCount;
+    private Integer averageTries;
+
+    public ProblemEntity convertToEntity() {
+        return ProblemEntity.builder()
+                .problemId(this.problemId)
+                .title(this.title)
+                .level(this.level)
+                .acceptedUserCount(this.acceptedUserCount)
+                .averageTries(this.averageTries)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/domain/ProblemTag.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/domain/ProblemTag.java
@@ -1,0 +1,25 @@
+package darkoverload.itzip.feature.algorithm.domain;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemTagEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemTag {
+    private Long bojTagId;
+    private String displayName;
+    private String displayNameSort;
+
+    public ProblemTagEntity convertToEntity() {
+        return ProblemTagEntity.builder()
+                .bojTagId(this.bojTagId)
+                .displayName(this.displayName)
+                .displayNameSort(this.displayNameSort)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/domain/ProblemTagMapping.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/domain/ProblemTagMapping.java
@@ -1,0 +1,25 @@
+package darkoverload.itzip.feature.algorithm.domain;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemTagMappingEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemTagMapping {
+    private Long id;
+    private Problem problemEntity;
+    private ProblemTag problemTagEntity;
+
+    public ProblemTagMappingEntity convertToEntity() {
+        return ProblemTagMappingEntity.builder()
+                .id(this.id)
+                .problemEntity(this.problemEntity.convertToEntity())
+                .problemTagEntity(this.problemTagEntity.convertToEntity())
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/domain/SolvedacUser.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/domain/SolvedacUser.java
@@ -1,0 +1,31 @@
+package darkoverload.itzip.feature.algorithm.domain;
+
+import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolvedacUser {
+    private Long userId;
+    private String username;
+    private Integer rating;
+    private Integer rank;
+    private LocalDateTime updateTime;
+
+    public SolvedacUserEntity convertToEntity() {
+        return SolvedacUserEntity.builder()
+                .userId(this.userId)
+                .username(this.username)
+                .rating(this.rating)
+                .rank(this.rank)
+                .updateTime(this.updateTime)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/domain/UserProblemMapping.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/domain/UserProblemMapping.java
@@ -1,0 +1,25 @@
+package darkoverload.itzip.feature.algorithm.domain;
+
+import darkoverload.itzip.feature.algorithm.entity.UserProblemMappingEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProblemMapping {
+    private Long id;
+    private SolvedacUser solvedacUserEntity;
+    private Problem problemEntity;
+
+    public UserProblemMappingEntity convertToEntity() {
+        return UserProblemMappingEntity.builder()
+                .id(this.id)
+                .solvedacUserEntity(this.solvedacUserEntity.convertToEntity())
+                .problemEntity(this.problemEntity.convertToEntity())
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
@@ -1,0 +1,40 @@
+package darkoverload.itzip.feature.algorithm.entity;
+
+import darkoverload.itzip.feature.algorithm.domain.Problem;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//solvedac문제를 저장할 엔티티
+@Entity
+@Table(name = "problems")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long problemId; // 문제 ID
+
+    private String title; // 문제 제목
+
+    private Integer level; // 문제 난이도
+
+    @Column(name = "accepted_user_count")
+    private Integer acceptedUserCount; // 문제를 푼 유저 수
+
+    private Integer averageTries; // 평균 시도 횟수
+
+    public Problem convertToDomain() {
+        return Problem.builder()
+                .problemId(this.problemId)
+                .title(this.title)
+                .level(this.level)
+                .acceptedUserCount(this.acceptedUserCount)
+                .averageTries(this.averageTries)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
@@ -1,11 +1,18 @@
 package darkoverload.itzip.feature.algorithm.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import darkoverload.itzip.feature.algorithm.domain.Problem;
+import darkoverload.itzip.feature.algorithm.domain.ProblemTagMapping;
+import darkoverload.itzip.feature.algorithm.domain.UserProblemMapping;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 //solvedac문제를 저장할 엔티티
 @Entity
@@ -27,6 +34,15 @@ public class ProblemEntity {
     private Integer acceptedUserCount; // 문제를 푼 유저 수
 
     private Integer averageTries; // 평균 시도 횟수
+
+    //jpa 쿼리를 사용하기위한 매핑 2가지
+    @OneToMany(mappedBy = "problemEntity", fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Set<UserProblemMappingEntity> userProblemMappings;
+
+    @OneToMany(mappedBy = "problem", fetch = FetchType.LAZY)
+    @JsonIgnore
+    private Set<ProblemTagMappingEntity> problemTagMappings = new HashSet<>();
 
     public Problem convertToDomain() {
         return Problem.builder()

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemEntity.java
@@ -2,8 +2,6 @@ package darkoverload.itzip.feature.algorithm.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import darkoverload.itzip.feature.algorithm.domain.Problem;
-import darkoverload.itzip.feature.algorithm.domain.ProblemTagMapping;
-import darkoverload.itzip.feature.algorithm.domain.UserProblemMapping;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 //solvedac문제를 저장할 엔티티
@@ -40,7 +37,7 @@ public class ProblemEntity {
     @JsonIgnore
     private Set<UserProblemMappingEntity> userProblemMappings;
 
-    @OneToMany(mappedBy = "problem", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "problemEntity", fetch = FetchType.LAZY)
     @JsonIgnore
     private Set<ProblemTagMappingEntity> problemTagMappings = new HashSet<>();
 

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemTagEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemTagEntity.java
@@ -1,0 +1,36 @@
+package darkoverload.itzip.feature.algorithm.entity;
+
+import darkoverload.itzip.feature.algorithm.domain.ProblemTag;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//문제의 Tag들을 저장하는 엔티티
+@Entity
+@Table(name = "problem_tags")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemTagEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long bojTagId; // 태그 ID
+
+    @Column(name = "display_name")
+    private String displayName; // 문제 유형 이름
+
+    @Column(name = "display_name_sort")
+    private String displayNameSort; // 문제 유형 별명
+
+    public ProblemTag convertToDomain() {
+        return ProblemTag.builder()
+                .bojTagId(this.bojTagId)
+                .displayName(this.displayName)
+                .displayNameSort(this.displayNameSort)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemTagMappingEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/ProblemTagMappingEntity.java
@@ -1,0 +1,38 @@
+package darkoverload.itzip.feature.algorithm.entity;
+
+import darkoverload.itzip.feature.algorithm.domain.ProblemTagMapping;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//문제랑 테그들을 매핑하는 테이블
+@Entity
+@Table(name = "problem_tag_mapping")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProblemTagMappingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 매핑 ID
+
+    @ManyToOne
+    @JoinColumn(name = "problem_id", nullable = false)
+    private ProblemEntity problemEntity; // 문제 ID (외래 키)
+
+    @ManyToOne
+    @JoinColumn(name = "boj_tag_id", nullable = false)
+    private ProblemTagEntity problemTagEntity; // 태그 ID (외래 키)
+
+    public ProblemTagMapping convertToDomain() {
+        return ProblemTagMapping.builder()
+                .id(this.id)
+                .problemEntity(this.problemEntity.convertToDomain())
+                .problemTagEntity(this.problemTagEntity.convertToDomain())
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/SolvedacUserEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/SolvedacUserEntity.java
@@ -1,0 +1,43 @@
+package darkoverload.itzip.feature.algorithm.entity;
+
+import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+//솔브드 ac 사용자 정보를 저장할 엔티티
+@Entity
+@Table(name = "solvedac_users")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolvedacUserEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId; // 유저 ID
+
+    @Column(nullable = false)
+    private String username; // 유저 이름
+
+    private Integer rating; // 솔브드 ac 레이팅
+
+    private Integer rank; // 솔브드 ac 랭킹
+
+    @Column(name = "update_time")
+    private LocalDateTime updateTime; // 문제 업데이트 시간
+
+    public SolvedacUser convertToDomain() {
+        return SolvedacUser.builder()
+                .userId(this.userId)
+                .username(this.username)
+                .rating(this.rating)
+                .rank(this.rank)
+                .updateTime(this.updateTime)
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/entity/UserProblemMappingEntity.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/entity/UserProblemMappingEntity.java
@@ -1,0 +1,37 @@
+package darkoverload.itzip.feature.algorithm.entity;
+
+import darkoverload.itzip.feature.algorithm.domain.UserProblemMapping;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+//사용자가 푼문제를 연결할 매핑 테이블
+@Entity
+@Table(name = "user_problem_mapping")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProblemMappingEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 매핑 ID
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private SolvedacUserEntity solvedacUserEntity; // 유저 ID (외래 키)
+
+    @ManyToOne
+    @JoinColumn(name = "problem_id", nullable = false)
+    private ProblemEntity problemEntity; // 문제 ID (외래 키)
+
+    public UserProblemMapping convertToDomain() {
+        return UserProblemMapping.builder()
+                .id(this.id)
+                .solvedacUserEntity(this.solvedacUserEntity.convertToDomain())
+                .problemEntity(this.problemEntity.convertToDomain())
+                .build();
+    }
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/ProblemRepository.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/ProblemRepository.java
@@ -1,0 +1,15 @@
+package darkoverload.itzip.feature.algorithm.repository.problem;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import darkoverload.itzip.feature.algorithm.repository.problem.custom.FindProblemByUser;
+import darkoverload.itzip.feature.algorithm.repository.problem.custom.FindProblemsByTagExcludingUserSolved;
+import darkoverload.itzip.feature.algorithm.repository.problem.custom.FindSolvedProlbmesByUserAndTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProblemRepository extends JpaRepository<ProblemEntity, Long>,
+        FindProblemByUser,
+        FindProblemsByTagExcludingUserSolved,
+        FindSolvedProlbmesByUserAndTag
+{}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindProblemByUser.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindProblemByUser.java
@@ -1,0 +1,17 @@
+package darkoverload.itzip.feature.algorithm.repository.problem.custom;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FindProblemByUser {
+    // 사용자가 해결한 문제를 제외하고 사용자의 tier랑 비슷한 문제를 찾는 메서드
+    // 사용자 티어에 2정도 차이나는 곳으로 문제를 묶고 문제를 맞은 사용자 수가 많은 순서대로 정렬
+    @Query("SELECT p FROM ProblemEntity p WHERE p.level BETWEEN :tier - 2 AND :tier + 2 " +
+            "AND p.problemId NOT IN (SELECT upm.problemEntity.problemId FROM UserProblemMappingEntity upm WHERE upm.solvedacUserEntity.userId = :userId) " +
+            "ORDER BY p.acceptedUserCount DESC")
+    List<ProblemEntity> findProblemByUser(@Param("userId") Long userId, @Param("tier") int tier, Pageable pageable);
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindProblemsByTagExcludingUserSolved.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindProblemsByTagExcludingUserSolved.java
@@ -1,0 +1,18 @@
+package darkoverload.itzip.feature.algorithm.repository.problem.custom;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FindProblemsByTagExcludingUserSolved {
+    // 사용자가 해결한 문제를 제외하고 특정 태그가 있는 문제를 찾는 메세드
+    // 평균 tier에 가까운 순서대로 정렬되고, 평균 tier에서 같은 거리에 있는 경우, 문제를 맞은 사용자 수가 많은 순서대로 정렬
+    @Query("SELECT p FROM ProblemEntity p JOIN p.problemTagMappings ptm " +
+            "WHERE ptm.problemTagEntity.bojTagId = :tagId AND p.problemId NOT IN " +
+            "(SELECT upm.problemEntity.problemId FROM UserProblemMappingEntity upm WHERE upm.solvedacUserEntity.userId = :userId) " +
+            "ORDER BY ABS(p.level - :averageTier) ASC, p.acceptedUserCount DESC")
+    List<ProblemEntity> findProblemsByTagExcludingUserSolved(@Param("userId") Long userId, @Param("tagId") Long tagId, @Param("averageTier") int averageTier, Pageable pageable);
+}

--- a/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindSolvedProlbmesByUserAndTag.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/repository/problem/custom/FindSolvedProlbmesByUserAndTag.java
@@ -1,0 +1,14 @@
+package darkoverload.itzip.feature.algorithm.repository.problem.custom;
+
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FindSolvedProlbmesByUserAndTag {
+    // 태그와 사용자의 id를 받아서 사용자가 푼 문제들을 찾아 반환하는 메서드
+    @Query("SELECT p FROM ProblemEntity p JOIN p.userProblemMappings upm JOIN p.problemTagMappings ptm " +
+            "WHERE upm.solvedacUserEntity.userId = :userId AND ptm.problemTagEntity.bojTagId = :tagId")
+    List<ProblemEntity> findSolvedProblemsByUserAndTag(@Param("userId") Long userId, @Param("tagId") Long tagId);
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/CsQuizController.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/CsQuizController.java
@@ -87,7 +87,6 @@ public class CsQuizController {
     @PostMapping("/answer")
     public UserQuizStatus submitAnswer(
             @SwaggerRequestBody(description = "제출할 문제의 정답 정보", required = true, content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = QuizAnswerRequest.class)
             )) @RequestBody QuizAnswerRequest quizAnswerRequest) {
         return quizService.checkAnswer(quizAnswerRequest);
@@ -105,7 +104,6 @@ public class CsQuizController {
     @PostMapping("/")
     public String createQuiz(
             @SwaggerRequestBody(description = "생성할 문제에 대한 정보", required = true, content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = QuizCreatedRequest.class)
             )) @RequestBody QuizCreatedRequest quizCreatedRequest) {
         quizService.createQuiz(quizCreatedRequest);

--- a/src/main/resources/sql/algorithm/algorithm.sql
+++ b/src/main/resources/sql/algorithm/algorithm.sql
@@ -1,0 +1,34 @@
+CREATE TABLE solvedac_users (
+                                user_id BIGSERIAL REFERENCES users(id),
+                                username VARCHAR(255),
+                                rating INTEGER,
+                                rank INTEGER,
+                                update_time TIMESTAMP,
+                                PRIMARY KEY (user_id)
+);
+
+CREATE TABLE problems (
+                          problem_id BIGSERIAL PRIMARY KEY,
+                          title VARCHAR(255),
+                          level INTEGER,
+                          accepted_user_count INTEGER,
+                          averageTries INTEGER
+);
+
+CREATE TABLE problem_tags (
+                              boj_tag_id BIGSERIAL PRIMARY KEY,
+                              display_name VARCHAR(255),
+                              display_name_sort VARCHAR(255)
+);
+
+CREATE TABLE user_problem_mapping (
+                                      id BIGSERIAL PRIMARY KEY,
+                                      user_id BIGINT REFERENCES solvedac_users(user_id) ON DELETE CASCADE,
+                                      problem_id BIGINT REFERENCES problems(problem_id) ON DELETE CASCADE
+);
+
+CREATE TABLE problem_tag_mapping (
+                                     id BIGSERIAL PRIMARY KEY,
+                                     problem_id BIGINT REFERENCES problems(problem_id) ON DELETE CASCADE,
+                                     boj_tag_id BIGINT REFERENCES problem_tags(boj_tag_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
1. 긴급 수정 : 엔티티로 변경을 하고 매핑에는 그렇게 적지 않아서 수정
2. @swaggerRequestBody부분의 설명이 제대로 적히지 않던 것을 수정 밑 미디어 타입을 지정하지 않아도 application/json으로 자동 지정되도록 변경
이로써 미디어타입을 지정하지 않아도 된다.
3. 파라메터가 없다면 스웨거에 No parameters가아닌 아예 안보이게 하려고 했으나 커스터마이징을 사용할때 Operation객체를 반환함으로써 swagger문서를 만들게 된다. 
이때 Operation객체에 parameters 필드가 존재하면 무조건 swagger에 parameters 섹션이 생긴다. 그래서 이걸 해결하려고 parameters가 없는 커스텀 Operation을 반환해보려했으나 이는 swagger문서를 생성해주지 않고, Map을 통해서 필드값을 삭제하고 다시 변환하는 방식도 사용해 봤으나 이는 반환 형에러를 가져온다. 어떤 방식을 써도 결국 Operation.class를 확장하거나(확장해서 필드값을 삭제하는 방식도 써봤으나 스웨거 생성을 안해줌), 생성해서 사용해야하는데 이럼 parameters필드가 결국 존재하게 되서 지금 제 지식으로는 parameters를 제거할 방법을 찾지 못했습니다 ㅠㅠㅠㅠㅠㅠㅠㅠ
(한국어로 된 레퍼런스는 못찾음 ... 영어는 못찾아봄)

브랜치 이름이 이상한건 알고리즘 만들다가 급하게 커밋하느라 못봤습니다 ><