### PR TITLE
🛠️ 리팩토링 : 회원 기능 GET 메소드 컨트롤러 파라미터 수신 방식 변경

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -8,6 +8,7 @@ import darkoverload.itzip.global.config.response.code.CommonResponseCode;
 import darkoverload.itzip.global.config.swagger.ExceptionCodeAnnotations;
 import darkoverload.itzip.global.config.swagger.ResponseCodeAnnotation;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -105,8 +106,12 @@ public class UserController {
     @GetMapping("/authEmail")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations({CommonExceptionCode.FILED_ERROR, CommonExceptionCode.NOT_MATCH_AUTH_CODE})
-    public ResponseEntity<String> checkAuthEmail(@RequestBody @Valid AuthEmailCheckRequest request, BindingResult bindingResult) {
-        return userService.checkAuthEmail(request, bindingResult);
+    public ResponseEntity<String> checkAuthEmail(
+            @Parameter(description = "이메일") @RequestParam(required = false) String email,
+            @Parameter(description = "이메일 인증 코드") @RequestParam(required = false) String authCode
+
+    ) {
+        return userService.checkAuthEmail(email, authCode);
     }
 
     /**
@@ -119,7 +124,9 @@ public class UserController {
     @GetMapping("/checkDuplicateEmail")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations({CommonExceptionCode.FILED_ERROR})
-    public ResponseEntity<String> checkDuplicateEmail(@RequestBody @Valid DuplicateEmailRequest request, BindingResult bindingResult) {
-        return userService.checkDuplicateEmail(request, bindingResult);
+    public ResponseEntity<String> checkDuplicateEmail(
+            @Parameter(description = "이메일") @RequestParam(required = false) String email
+    ) {
+        return userService.checkDuplicateEmail(email);
     }
 }

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
@@ -21,9 +21,9 @@ public interface UserService {
 
     ResponseEntity<String> sendAuthEmail(AuthEmailSendRequest emailSendRequest, BindingResult bindingResult);
 
-    ResponseEntity<String> checkAuthEmail(AuthEmailCheckRequest request, BindingResult bindingResult);
+    ResponseEntity<String> checkAuthEmail(String email, String authCode);
 
-    ResponseEntity<String> checkDuplicateEmail(DuplicateEmailRequest request, BindingResult bindingResult);
+    ResponseEntity<String> checkDuplicateEmail(String email);
 
     String getUniqueNickname();
 

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -241,14 +241,16 @@ public class UserServiceImpl implements UserService {
      * 인증번호 검증
      */
     @Override
-    public ResponseEntity<String> checkAuthEmail(AuthEmailCheckRequest request, BindingResult bindingResult) {
-        // 필드 에러 확인
-        if (bindingResult.hasErrors()) {
+    public ResponseEntity<String> checkAuthEmail(String email, String authCode) {
+        String emailPattern = "^[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$";
+
+        // 입력값이 비정상적일 경우
+        if (email == null || authCode == null || !email.matches(emailPattern)) {
             throw new RestApiException(CommonExceptionCode.FILED_ERROR);
         }
 
         // redis에 저장된 인증번호와 비교하여 확인
-        if (!verificationService.verifyCode(request.getEmail(), request.getAuthCode())) {
+        if (!verificationService.verifyCode(email, authCode)) {
             throw new RestApiException(CommonExceptionCode.NOT_MATCH_AUTH_CODE);
         }
 
@@ -256,21 +258,19 @@ public class UserServiceImpl implements UserService {
     }
 
     /**
-     * 사용 중인 이메일인지 체크하는 메소드
-     *
-     * @param request
-     * @param bindingResult
-     * @return
+     * 사용 중인 이메일인지 체크
      */
     @Override
-    public ResponseEntity<String> checkDuplicateEmail(DuplicateEmailRequest request, BindingResult bindingResult) {
-        // 필드 에러 확인
-        if (bindingResult.hasErrors()) {
+    public ResponseEntity<String> checkDuplicateEmail(String email) {
+        String emailPattern = "^[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\\.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,3}$";
+
+        // 이메일 패턴이 아닐 경우
+        if (email == null || !email.matches(emailPattern)) {
             throw new RestApiException(CommonExceptionCode.FILED_ERROR);
         }
 
         // 중복 이메일 체크
-        userRepository.findByEmail(request.getEmail()).ifPresent(user -> {
+        userRepository.findByEmail(email).ifPresent(user -> {
             throw new RestApiException(CommonExceptionCode.EXIST_EMAIL_ERROR);
         });
         return ResponseEntity.ok("사용 가능한 이메일입니다.");


### PR DESCRIPTION
현재 공통 예외처리가 @RequestParam validation 예외처리를 하지 못하기 때문에 비즈니스 로직에 예외처리 코드를 추가했습니다.
추후 공통 예외처리가 수정될 경우 해당 코드도 수정할 예정입니다. 

Resolves: #106
Related to: #109 