### PR TITLE
♻️ 코드 리팩토링 : solved.ac사용자 프로필 저장 방식 변경 + 테스트코드 수정

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImpl.java
@@ -5,6 +5,7 @@ import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
 import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
 import darkoverload.itzip.feature.algorithm.util.SaveSolvedUser;
 import darkoverload.itzip.feature.algorithm.util.SaveUserSolvedProblem;
+import darkoverload.itzip.feature.image.service.CloudStorageService;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +22,13 @@ public class UpdateUserSolvedProfileAndProblemServiceImpl implements UpdateUserS
     private final SaveUserSolvedProblem saveUserSolvedProblem;
 
     private final SolvedacUserRepository solvedacUserRepository;
+    private final CloudStorageService cloudStorageService;
 
     /** todo
      *     디버깅 단계에서는 10초로 하기로함 ver1시에 다시 변경함
      */
 //    @Value("${SOLVED_AC_USER_UPDATE_COOLDOWN_HOURS}")
-    private long updateCooldownHours = 1 / 360L;
+    private long updateCooldownSeconds = 10L;
     /**
      * 사용자의 sovledac계정과 username을 업데이트하는 메서드
      * 시간에 제한이 있다.
@@ -34,6 +36,9 @@ public class UpdateUserSolvedProfileAndProblemServiceImpl implements UpdateUserS
     @Override
     @Transactional
     public SolvedUserResponse updateUserSolvedProfileAndProblem(Long userId) {
+        //solvedac 프로필 사진이 저장되는 디렉토리
+        final String solvedAcProfileDir = "solvedacProfile";
+
         SolvedacUser solvedacUser = solvedacUserRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_FOUND_SOLVEDAC_USER))
                 .convertToDomain();
@@ -41,9 +46,12 @@ public class UpdateUserSolvedProfileAndProblemServiceImpl implements UpdateUserS
         //사용자가 업데이트 할수 있는 시간인지 확인
         LocalDateTime currentTime = LocalDateTime.now();
         Duration duration = Duration.between(solvedacUser.getUpdateTime(), currentTime);
-        if (duration.toHours() > updateCooldownHours){
+        if (duration.toSeconds() > updateCooldownSeconds){
             //사용자가 푼 문제들 저장
             saveUserSolvedProblem.saveUserSolvedProblem(userId);
+
+            //사용자 기존 사진 삭제
+            cloudStorageService.imageDelete(solvedacUser.getProfileImageUrl(), solvedAcProfileDir);
 
             //업데이트된 사용자 정보를 저장하고 return
             return SolvedUserResponse.builder()

--- a/src/main/java/darkoverload/itzip/feature/algorithm/util/SaveSolvedUser.java
+++ b/src/main/java/darkoverload/itzip/feature/algorithm/util/SaveSolvedUser.java
@@ -5,12 +5,19 @@ import com.google.gson.JsonParser;
 import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
 import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
 import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
+import darkoverload.itzip.feature.image.domain.Image;
+import darkoverload.itzip.feature.image.service.CloudStorageService;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
+import darkoverload.itzip.global.entity.CustomMultipartFile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.LocalDateTime;
 
@@ -20,6 +27,7 @@ import java.time.LocalDateTime;
 public class SaveSolvedUser {
     private final SolvedacUserRepository solvedacUserRepository;
     private final SolvedAcAPI solvedAcAPI;
+    private final CloudStorageService cloudStorageService;
 
     /**
      * 사용자 정보 업데이트 혹은 저장 메서드
@@ -27,6 +35,9 @@ public class SaveSolvedUser {
      * @param username 사용자 이름
      */
     public SolvedacUser saveSolvedUser(Long userId, String username) {
+        //solvedac 프로필 사진이 저장되는 디렉토리
+        final String solvedAcProfileDir = "solvedacProfile";
+
         try{
             HttpResponse<String> response = solvedAcAPI.solvedacAPIRequest(solvedAcAPI.getUserByName(username));
             JsonObject jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
@@ -35,13 +46,17 @@ public class SaveSolvedUser {
                 throw new RestApiException(CommonExceptionCode.NOT_FOUND_SOLVEDAC_USERNAME);
             }
 
+            MultipartFile multipartFile = downloadImageAsMultipartFile(jsonObject.get("profileImageUrl").getAsString(), username);
+
+            Image image = cloudStorageService.imageUpload(multipartFile, solvedAcProfileDir);
+
             SolvedacUserEntity solvedacUserEntity = SolvedacUserEntity.builder()
                     .userId(userId)
                     .username(username)
                     .rating(jsonObject.get("rating").getAsInt())
                     .rank(jsonObject.get("rank").getAsInt())
                     .updateTime(LocalDateTime.now())
-                    .profileImageUrl(jsonObject.get("profileImageUrl").getAsString())
+                    .profileImageUrl(image.getImagePath())
                     .solvedClass(jsonObject.get("class").getAsInt())
                     .tier(jsonObject.get("tier").getAsInt())
                     .build();
@@ -52,6 +67,31 @@ public class SaveSolvedUser {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RestApiException(CommonExceptionCode.SOLVED_USER_SOLVED_ERROR);
+        }
+    }
+
+    /**
+     * 이미지 url를 사진을 다운로드해 multifile 변환
+     * @param imageUrl 이미지 주소
+     * @return MultipartFile 형 이미지
+     * @throws IOException url에 에러가 있을시 예외 출력
+     */
+    public MultipartFile downloadImageAsMultipartFile(String imageUrl, String username) {
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(imageUrl))
+                    .build();
+
+            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            byte[] imageBytes = response.body();
+
+            client.close();
+            return new CustomMultipartFile(imageBytes, username + ".jpg", "image/jpeg");
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RestApiException(CommonExceptionCode.SOLVEDAC_PROFILEIMAGE_URL_ERROR);
         }
     }
 }

--- a/src/main/java/darkoverload/itzip/global/config/response/code/CommonExceptionCode.java
+++ b/src/main/java/darkoverload/itzip/global/config/response/code/CommonExceptionCode.java
@@ -129,6 +129,8 @@ public enum CommonExceptionCode implements ResponseCode {
     UPDATE_COOLDOWN(HttpStatus.CONFLICT, "마지막 업데이트로부터 시간이 지나지 않았습니다."),
     //solved.ac 서버로부터 api를 받아올수 없습니다.
     SOLVEDAC_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "solved.ac로부터 오류를 보냈습니다."),
+    //solved.ac 로부터 받아온 url에 에러가 생겼습니다.
+    SOLVEDAC_PROFILEIMAGE_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "solved.ac로부터 받은 image url에 에러가 있습니다."),
 
     /**
      * Resume Error

--- a/src/main/java/darkoverload/itzip/global/entity/CustomMultipartFile.java
+++ b/src/main/java/darkoverload/itzip/global/entity/CustomMultipartFile.java
@@ -1,0 +1,63 @@
+package darkoverload.itzip.global.entity;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+
+/**
+ * 멀티파일 생성을 위함 클래스
+ */
+public class CustomMultipartFile implements MultipartFile {
+
+    private final byte[] fileContent;
+    private final String fileName;
+    private final String contentType;
+
+    public CustomMultipartFile(byte[] fileContent, String fileName, String contentType) {
+        this.fileContent = fileContent;
+        this.fileName = fileName;
+        this.contentType = contentType;
+    }
+
+    @Override
+    public String getName() {
+        return fileName;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return fileName;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return fileContent.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return fileContent.length;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return fileContent;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(fileContent);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(dest)) {
+            out.write(fileContent);
+        }
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/FindProblemsByTagAndUserServiceTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/FindProblemsByTagAndUserServiceTest.java
@@ -1,0 +1,67 @@
+package darkoverload.itzip.feature.algorithm.service.problem;
+
+import darkoverload.itzip.feature.algorithm.controller.response.ProblemListResponse;
+import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
+import darkoverload.itzip.feature.algorithm.repository.problem.ProblemRepository;
+import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
+import darkoverload.itzip.feature.algorithm.util.SolvedTierCalculator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class FindProblemsByTagAndUserServiceImplTest {
+
+    @Mock
+    private ProblemRepository problemRepository;
+
+    @Mock
+    private SolvedacUserRepository solvedacUserRepository;
+
+    @Mock
+    private SolvedTierCalculator solvedTierCalculator;
+
+    @InjectMocks
+    private FindProblemsByTagAndUserServiceImpl findProblemsByTagAndUserService;
+
+    @Test
+    void 사용자_아이디와_테그_아이디로_문제를_추천() {
+        Long userId = 1L;
+        Long tagId = 2L;
+
+        SolvedacUserEntity solvedacUserEntity = mock(SolvedacUserEntity.class);
+        SolvedacUser solvedacUser = mock(SolvedacUser.class);
+
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.of(solvedacUserEntity));
+        when(solvedacUserEntity.convertToDomain()).thenReturn(solvedacUser);
+        when(solvedacUser.getTier()).thenReturn(10);
+
+        when(solvedTierCalculator.tagRatingCalculator(any())).thenReturn(8);
+        when(solvedTierCalculator.tierCalculator(8)).thenReturn(8);
+
+        List<ProblemEntity> problemEntities = List.of(mock(ProblemEntity.class));
+        when(problemRepository.findProblemsByTagExcludingUserSolved(userId, tagId, 9, PageRequest.of(0, 10)))
+                .thenReturn(problemEntities);
+
+        ProblemListResponse response = findProblemsByTagAndUserService.findProblemsByTagAndUser(userId, tagId);
+
+        assertNotNull(response);
+        assertEquals(problemEntities.size(), response.getProblems().size());
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/FindProblemsByUserServiceTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/FindProblemsByUserServiceTest.java
@@ -1,0 +1,55 @@
+package darkoverload.itzip.feature.algorithm.service.problem;
+
+import darkoverload.itzip.feature.algorithm.controller.response.ProblemListResponse;
+import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
+import darkoverload.itzip.feature.algorithm.entity.ProblemEntity;
+import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
+import darkoverload.itzip.feature.algorithm.repository.problem.ProblemRepository;
+import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FindProblemsByUserServiceImplTest {
+
+    @Mock
+    private ProblemRepository problemRepository;
+
+    @Mock
+    private SolvedacUserRepository solvedacUserRepository;
+
+    @InjectMocks
+    private FindProblemsByUserServiceImpl findProblemsByUserService;
+
+    @Test
+    void 사용자의_tier_기준으로_문제를_추천() {
+        Long userId = 1L;
+        SolvedacUserEntity solvedacUserEntity = mock(SolvedacUserEntity.class);
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.of(solvedacUserEntity));
+
+        SolvedacUser solvedacUser = mock(SolvedacUser.class);
+        when(solvedacUserEntity.convertToDomain()).thenReturn(solvedacUser);
+        when(solvedacUser.getTier()).thenReturn(5);
+
+        List<ProblemEntity> problemEntities = List.of(mock(ProblemEntity.class));
+        when(problemRepository.findProblemsByUser(userId, 5, PageRequest.of(0, 10)))
+                .thenReturn(problemEntities);
+
+        ProblemListResponse response = findProblemsByUserService.findProblemsByUser(userId);
+
+        assertNotNull(response);
+        assertEquals(problemEntities.size(), response.getProblems().size());
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/SaveProblemsServiceTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/problem/SaveProblemsServiceTest.java
@@ -1,0 +1,7 @@
+package darkoverload.itzip.feature.algorithm.service.problem;
+
+/**Todo
+ *
+ */
+public class SaveProblemsServiceTest {
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/tag/FindAllTagsServiceImplTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/tag/FindAllTagsServiceImplTest.java
@@ -1,0 +1,49 @@
+package darkoverload.itzip.feature.algorithm.service.tag;
+
+import darkoverload.itzip.feature.algorithm.controller.response.SolvedTagResponse;
+import darkoverload.itzip.feature.algorithm.entity.ProblemTagEntity;
+import darkoverload.itzip.feature.algorithm.repository.tag.ProblemTagRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class FindAllTagsServiceImplTest {
+
+    @Mock
+    private ProblemTagRepository problemTagRepository;
+
+    @InjectMocks
+    private FindAllTagsServiceImpl findAllTagsService;
+
+    @Test
+    void 모든_태그를_가져오는_테스트() {
+        List<ProblemTagEntity> allTags = List.of(mock(ProblemTagEntity.class), mock(ProblemTagEntity.class));
+        when(problemTagRepository.findAll()).thenReturn(allTags);
+
+        SolvedTagResponse response = findAllTagsService.findSolvedTags(false);
+
+        assertNotNull(response);
+        assertEquals(allTags.size(), response.getTags().size());
+    }
+
+    @Test
+    void 추천된_태그만_가져오는_테스트() {
+        List<ProblemTagEntity> recommendedTagEntities = List.of(mock(ProblemTagEntity.class), mock(ProblemTagEntity.class));
+        when(problemTagRepository.findAllById(anyList())).thenReturn(recommendedTagEntities);
+
+        SolvedTagResponse response = findAllTagsService.findSolvedTags(true);
+
+        assertNotNull(response);
+        assertEquals(recommendedTagEntities.size(), response.getTags().size());
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/tag/SaveTagsServiceTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/tag/SaveTagsServiceTest.java
@@ -1,0 +1,7 @@
+package darkoverload.itzip.feature.algorithm.service.tag;
+
+/**Todo
+ *
+ */
+public class SaveTagsServiceTest {
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/user/FindUserSolvedProfileServiceImplTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/user/FindUserSolvedProfileServiceImplTest.java
@@ -1,0 +1,49 @@
+package darkoverload.itzip.feature.algorithm.service.user;
+
+import darkoverload.itzip.feature.algorithm.controller.response.SolvedUserResponse;
+import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
+import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FindUserSolvedProfileServiceImplTest {
+
+    @Mock
+    private SolvedacUserRepository solvedacUserRepository;
+
+    @InjectMocks
+    private FindUserSolvedProfileServiceImpl findUserSolvedProfileService;
+
+    @Test
+    void 사용자_프로필_정상_반환() {
+        Long userId = 1L;
+        SolvedacUserEntity solvedacUserEntity = mock(SolvedacUserEntity.class);
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.of(solvedacUserEntity));
+
+        SolvedUserResponse response = findUserSolvedProfileService.findUserSolvedProfile(userId);
+
+        assertEquals(solvedacUserEntity.convertToDomain(), response.getSolvedacUser());
+    }
+
+    @Test
+    void 사용자_프로필_없을_경우_예외() {
+        Long userId = 2L;
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.empty());
+
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                findUserSolvedProfileService.findUserSolvedProfile(userId)
+        );
+        assertEquals(CommonExceptionCode.NOT_FOUND_SOLVEDAC_USER, exception.getExceptionCode());
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/user/SaveUserSolvedProfileServiceImplTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/user/SaveUserSolvedProfileServiceImplTest.java
@@ -1,0 +1,34 @@
+package darkoverload.itzip.feature.algorithm.service.user;
+
+import darkoverload.itzip.feature.algorithm.util.SaveSolvedUser;
+import darkoverload.itzip.feature.algorithm.util.SaveUserSolvedProblem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SaveUserSolvedProfileServiceImplTest {
+
+    @Mock
+    private SaveSolvedUser saveSolvedUser;
+
+    @Mock
+    private SaveUserSolvedProblem saveUserSolvedProblem;
+
+    @InjectMocks
+    private SaveUserSolvedProfileServiceImpl saveUserSolvedProfileService;
+
+    @Test
+    void 사용자_프로필_저장() {
+        Long userId = 1L;
+        String username = "exampleUsername";
+
+        saveUserSolvedProfileService.saveUserSolvedProfile(userId, username);
+
+        verify(saveSolvedUser).saveSolvedUser(userId, username);
+        verify(saveUserSolvedProblem).saveUserSolvedProblem(userId);
+    }
+}

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImplTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImplTest.java
@@ -6,6 +6,7 @@ import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
 import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
 import darkoverload.itzip.feature.algorithm.util.SaveSolvedUser;
 import darkoverload.itzip.feature.algorithm.util.SaveUserSolvedProblem;
+import darkoverload.itzip.feature.image.service.CloudStorageService;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,9 @@ class UpdateUserSolvedProfileAndProblemServiceImplTest {
 
     @Mock
     private SolvedacUserRepository solvedacUserRepository;
+
+    @Mock
+    private CloudStorageService cloudStorageService;
 
     @InjectMocks
     private UpdateUserSolvedProfileAndProblemServiceImpl updateUserSolvedProfileAndProblemService;

--- a/src/test/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImplTest.java
+++ b/src/test/java/darkoverload/itzip/feature/algorithm/service/user/UpdateUserSolvedProfileAndProblemServiceImplTest.java
@@ -1,0 +1,70 @@
+package darkoverload.itzip.feature.algorithm.service.user;
+
+import darkoverload.itzip.feature.algorithm.controller.response.SolvedUserResponse;
+import darkoverload.itzip.feature.algorithm.domain.SolvedacUser;
+import darkoverload.itzip.feature.algorithm.entity.SolvedacUserEntity;
+import darkoverload.itzip.feature.algorithm.repository.user.SolvedacUserRepository;
+import darkoverload.itzip.feature.algorithm.util.SaveSolvedUser;
+import darkoverload.itzip.feature.algorithm.util.SaveUserSolvedProblem;
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserSolvedProfileAndProblemServiceImplTest {
+
+    @Mock
+    private SaveSolvedUser saveSolvedUser;
+
+    @Mock
+    private SaveUserSolvedProblem saveUserSolvedProblem;
+
+    @Mock
+    private SolvedacUserRepository solvedacUserRepository;
+
+    @InjectMocks
+    private UpdateUserSolvedProfileAndProblemServiceImpl updateUserSolvedProfileAndProblemService;
+
+    @Test
+    void 사용자가_업데이트_쿨다운을_지켰을_경우_프로필_업데이트() {
+        Long userId = 1L;
+        SolvedacUserEntity solvedacUserEntity = mock(SolvedacUserEntity.class);
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.of(solvedacUserEntity));
+
+        SolvedacUser solvedacUser = mock(SolvedacUser.class);
+        when(solvedacUserEntity.convertToDomain()).thenReturn(solvedacUser);
+        when(solvedacUser.getUpdateTime()).thenReturn(LocalDateTime.now().minusHours(2));
+
+        when(saveSolvedUser.saveSolvedUser(userId, solvedacUser.getUsername())).thenReturn(solvedacUser);
+
+        SolvedUserResponse response = updateUserSolvedProfileAndProblemService.updateUserSolvedProfileAndProblem(userId);
+
+        assertNotNull(response);
+        assertEquals(solvedacUser, response.getSolvedacUser());
+        verify(saveUserSolvedProblem).saveUserSolvedProblem(userId);
+    }
+
+    @Test
+    void 사용자가_업데이트_쿨다운_미준수시_예외_발생() {
+        Long userId = 1L;
+        SolvedacUserEntity solvedacUserEntity = mock(SolvedacUserEntity.class);
+        when(solvedacUserRepository.findById(userId)).thenReturn(Optional.of(solvedacUserEntity));
+
+        SolvedacUser solvedacUser = mock(SolvedacUser.class);
+        when(solvedacUserEntity.convertToDomain()).thenReturn(solvedacUser);
+        when(solvedacUser.getUpdateTime()).thenReturn(LocalDateTime.now());
+
+        RestApiException exception = assertThrows(RestApiException.class, () ->
+                updateUserSolvedProfileAndProblemService.updateUserSolvedProfileAndProblem(userId)
+        );
+        assertEquals(CommonExceptionCode.UPDATE_COOLDOWN, exception.getExceptionCode());
+    }
+}


### PR DESCRIPTION
### **📋 설명**
solvedac url을 그대로 사용할경우 프론트엔드에서 사진이 다운로드 되는 현상이 발생 따라서 사진을 itzipdb로 저장하고 프론트에서 사용하도록 코드 변경

    @Mock
    private CloudStorageService cloudStorageService;
    를 test코드에서 사용하지 않는데 Mock으로 만들어줘야 에러가 생기지 않는 것이 의문 왜이럼용?