### PR TITLE
🛠️ 리팩토링: JWT 인증 방식 쿠키 -> 헤더로 변경

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/darkoverload/itzip/feature/jwt/filter/TokenAuthenticationFilter.java
@@ -4,7 +4,6 @@ import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
 import darkoverload.itzip.feature.jwt.infrastructure.JwtAuthenticationToken;
 import darkoverload.itzip.feature.jwt.util.JwtTokenizer;
 import darkoverload.itzip.feature.user.entity.Authority;
-import darkoverload.itzip.feature.user.util.CookieUtils;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
 import io.jsonwebtoken.Claims;
@@ -29,12 +28,14 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * JWT 토큰 인증 필터 클래스
+ * JWT 인증 필터 클래스
  */
 @Slf4j
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     /**
      * 필터 메서드
@@ -49,7 +50,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 쿠키에 저장된 accessToken 값을 가져옴
-        String accessToken = CookieUtils.findCookieValue(request, "accessToken").orElse(null);
+        String accessToken = resolveToken(request);
 
         if (StringUtils.hasText(accessToken)) {
             try {
@@ -77,7 +78,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private void getAuthentication(String token) {
         Claims claims = jwtTokenizer.parseAccessToken(token); // 토큰에서 클레임을 파싱
         String email = claims.getSubject(); // 이메일을 가져옴
-        Long userId = claims.get("userId", Long.class); // 사용자 ID를 가져옴
         String nickname = claims.get("nickname", String.class); // 이름을 가져옴
         Authority authority = Authority.valueOf(claims.get("authority", String.class)); // 사용자 권한을 가져옴
 
@@ -86,5 +86,16 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         CustomUserDetails userDetails = new CustomUserDetails(email, "", nickname, (List<GrantedAuthority>) authorities);
         Authentication authentication = new JwtAuthenticationToken(authorities, userDetails, null); // 인증 객체 생성
         SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContextHolder에 인증 객체 설정
+    }
+
+    /**
+     * Request Header에서 토큰 정보를 꺼내오기 위한 resolveToken 메서드
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/darkoverload/itzip/feature/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/darkoverload/itzip/feature/jwt/filter/TokenAuthenticationFilter.java
@@ -35,8 +35,6 @@ import java.util.List;
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenizer jwtTokenizer;
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-
     /**
      * 필터 메서드
      * 각 요청마다 JWT 토큰을 검증하고 인증을 설정
@@ -50,7 +48,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 쿠키에 저장된 accessToken 값을 가져옴
-        String accessToken = resolveToken(request);
+        String accessToken = jwtTokenizer.resolveAccessToken(request);
 
         if (StringUtils.hasText(accessToken)) {
             try {
@@ -86,16 +84,5 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         CustomUserDetails userDetails = new CustomUserDetails(email, "", nickname, (List<GrantedAuthority>) authorities);
         Authentication authentication = new JwtAuthenticationToken(authorities, userDetails, null); // 인증 객체 생성
         SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContextHolder에 인증 객체 설정
-    }
-
-    /**
-     * Request Header에서 토큰 정보를 꺼내오기 위한 resolveToken 메서드
-     */
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
     }
 }

--- a/src/main/java/darkoverload/itzip/feature/jwt/util/JwtTokenizer.java
+++ b/src/main/java/darkoverload/itzip/feature/jwt/util/JwtTokenizer.java
@@ -7,8 +7,10 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -23,6 +25,8 @@ public class JwtTokenizer {
     private final byte[] refreshSecret;
     public static Long accessTokenExpire;
     public static Long refreshTokenExpire;
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     public JwtTokenizer(@Value("${jwt.accessSecret}") String accessSecret, @Value("${jwt.refreshSecret}") String refreshSecret, @Value("${jwt.accessTokenExpire}") Long accessTokenExpire, @Value("${jwt.refreshTokenExpire}") Long refreshTokenExpire) {
         this.accessSecret = accessSecret.getBytes(StandardCharsets.UTF_8);
@@ -140,5 +144,16 @@ public class JwtTokenizer {
      */
     public static Key getSigningKey(byte[] secretKey) {
         return Keys.hmacShaKeyFor(secretKey);
+    }
+
+    /**
+     * Request Header에서 토큰 정보를 꺼내오기 위한 resolveToken 메서드
+     */
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/darkoverload/itzip/feature/jwt/util/JwtTokenizer.java
+++ b/src/main/java/darkoverload/itzip/feature/jwt/util/JwtTokenizer.java
@@ -5,6 +5,7 @@ import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -101,6 +102,7 @@ public class JwtTokenizer {
 
     /**
      * access token 파싱
+     *
      * @param accessToken access token
      * @return 파싱된 토큰
      */
@@ -110,6 +112,7 @@ public class JwtTokenizer {
 
     /**
      * refresh token 파싱
+     *
      * @param refreshToken refresh token
      * @return 파싱된 토큰
      */
@@ -119,7 +122,8 @@ public class JwtTokenizer {
 
     /**
      * token 파싱
-     * @param token access/refresh token
+     *
+     * @param token     access/refresh token
      * @param secretKey access/refresh 비밀키
      * @return 파싱된 토큰
      */
@@ -131,7 +135,7 @@ public class JwtTokenizer {
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-        } catch (SignatureException e) { // 토큰 유효성 체크 실패 시
+        } catch (SignatureException | MalformedJwtException e) {  // 토큰 유효성 체크 실패 시
             throw new RestApiException(CommonExceptionCode.JWT_INVALID_ERROR);
         }
 

--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -55,8 +54,8 @@ public class UserController {
     @PostMapping("/login")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations({CommonExceptionCode.FILED_ERROR, CommonExceptionCode.NOT_MATCH_PASSWORD})
-    public ResponseEntity<UserLoginResponse> login(@RequestBody @Valid UserLoginRequest userLoginRequest, HttpServletResponse httpServletResponse) {
-        return userService.login(userLoginRequest, httpServletResponse);
+    public ResponseEntity<UserLoginResponse> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
+        return userService.login(userLoginRequest);
     }
 
     /**
@@ -68,8 +67,8 @@ public class UserController {
     )
     @DeleteMapping("/logout")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
-    public String logout(HttpServletRequest request, HttpServletResponse response) {
-        return userService.logout(request, response);
+    public String logout(HttpServletRequest request) {
+        return userService.logout(request);
     }
 
     /**
@@ -82,8 +81,8 @@ public class UserController {
     @PatchMapping("/refreshToken")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations({CommonExceptionCode.JWT_UNKNOWN_ERROR, CommonExceptionCode.NOT_FOUND_USER})
-    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        return userService.refreshToken(request, response);
+    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request) {
+        return userService.refreshToken(request);
     }
 
     /**
@@ -110,8 +109,8 @@ public class UserController {
     @PostMapping("/authEmail")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations(CommonExceptionCode.FILED_ERROR)
-    public String sendAuthEmail(@RequestBody @Valid AuthEmailSendRequest request) {
-        return userService.sendAuthEmail(request);
+    public String sendAuthEmail(@RequestBody @Valid AuthEmailSendRequest authEmailSendRequest) {
+        return userService.sendAuthEmail(authEmailSendRequest);
     }
 
     /**
@@ -159,9 +158,8 @@ public class UserController {
     @ExceptionCodeAnnotations({CommonExceptionCode.FILED_ERROR, CommonExceptionCode.NOT_FOUND_USER})
     public String tempUserOut(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            HttpServletRequest request,
-            HttpServletResponse response
+            HttpServletRequest request
     ) {
-        return userService.tempUserOut(userDetails, request, response);
+        return userService.tempUserOut(userDetails, request);
     }
 }

--- a/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/UserController.java
@@ -80,9 +80,9 @@ public class UserController {
     )
     @PatchMapping("/refreshToken")
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
-    @ExceptionCodeAnnotations({CommonExceptionCode.JWT_UNKNOWN_ERROR, CommonExceptionCode.NOT_FOUND_USER})
-    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request) {
-        return userService.refreshToken(request);
+    @ExceptionCodeAnnotations(CommonExceptionCode.FILED_ERROR)
+    public ResponseEntity<UserLoginResponse> refreshAccessToken(@RequestBody @Valid RefreshAccessTokenRequest refreshAccessTokenRequest) {
+        return userService.refreshAccessToken(refreshAccessTokenRequest);
     }
 
     /**

--- a/src/main/java/darkoverload/itzip/feature/user/controller/request/RefreshAccessTokenRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/request/RefreshAccessTokenRequest.java
@@ -1,0 +1,16 @@
+package darkoverload.itzip.feature.user.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshAccessTokenRequest {
+    @NotBlank(message = "리프레시 토큰 값을 입력해주세요.")
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.VFb0qJ1LRg_4ujbZoRMXnVkUgiuKq5KxWqNdbKq_G9Vvz-S1zZa9LPxtHWKa64zDl2ofkT8F6jBt_K4riU-fPg")
+    private String refreshToken;
+}

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
@@ -14,15 +14,15 @@ import java.util.Optional;
 public interface UserService {
     ResponseEntity<UserInfoResponse> getUserInfo(CustomUserDetails userDetails);
 
-    ResponseEntity<UserLoginResponse> login(UserLoginRequest userLoginRequest, HttpServletResponse httpServletResponse);
+    ResponseEntity<UserLoginResponse> login(UserLoginRequest userLoginRequest);
 
-    String logout(HttpServletRequest request, HttpServletResponse response);
+    String logout(HttpServletRequest request);
 
-    ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request, HttpServletResponse response);
+    ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request);
 
     String save(UserJoinRequest userJoinRequest);
 
-    String sendAuthEmail(AuthEmailSendRequest emailSendRequest);
+    String sendAuthEmail(AuthEmailSendRequest authEmailSendRequest);
 
     String checkAuthEmail(String email, String authCode);
 
@@ -40,5 +40,5 @@ public interface UserService {
 
     String encryptPassword(String password);
 
-    String tempUserOut(CustomUserDetails userDetails, HttpServletRequest request, HttpServletResponse response);
+    String tempUserOut(CustomUserDetails userDetails, HttpServletRequest request);
 }

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserService.java
@@ -18,7 +18,7 @@ public interface UserService {
 
     String logout(HttpServletRequest request);
 
-    ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request);
+    ResponseEntity<UserLoginResponse> refreshAccessToken(RefreshAccessTokenRequest refreshAccessTokenRequest);
 
     String save(UserJoinRequest userJoinRequest);
 

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -16,7 +16,6 @@ import darkoverload.itzip.feature.user.util.RandomNickname;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.exception.RestApiException;
 import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -109,7 +108,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public String logout(HttpServletRequest request, HttpServletResponse response) {
         // access token 가져오기
-        String accessToken = CookieUtils.findCookieValue(request, "accessToken").orElse(null);
+        String accessToken = jwtTokenizer.resolveAccessToken(request);
 
         // tokens 데이터 삭제
         tokenService.deleteByAccessToken(accessToken);
@@ -140,14 +139,6 @@ public class UserServiceImpl implements UserService {
 
         // Token 데이터 access token 값 업데이트
         tokenService.updateByRefreshToken(refreshToken, accessToken);
-
-        // accessToken 쿠키 생성
-        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(Math.toIntExact(JwtTokenizer.accessTokenExpire / 1000));
-
-        response.addCookie(accessTokenCookie);
 
         // 응답 값
         UserLoginResponse userLoginResponse = UserLoginResponse.builder()

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -92,19 +92,6 @@ public class UserServiceImpl implements UserService {
 
         tokenService.saveOrUpdate(token);
 
-        // 토큰 쿠키 저장
-        Cookie accessTokenCookie = new Cookie("accessToken", accessToken);
-        accessTokenCookie.setHttpOnly(true);
-        accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(Math.toIntExact(JwtTokenizer.accessTokenExpire / 1000));
-        httpServletResponse.addCookie(accessTokenCookie);
-
-        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(Math.toIntExact(JwtTokenizer.refreshTokenExpire / 1000));
-        httpServletResponse.addCookie(refreshTokenCookie);
-
         // 응답 값
         UserLoginResponse userLoginResponse = UserLoginResponse.builder()
                 .accessToken(accessToken)
@@ -123,11 +110,6 @@ public class UserServiceImpl implements UserService {
     public String logout(HttpServletRequest request, HttpServletResponse response) {
         // access token 가져오기
         String accessToken = CookieUtils.findCookieValue(request, "accessToken").orElse(null);
-
-        // access token 삭제
-        CookieUtils.deleteCookie(response, "accessToken");
-        // refresh token 삭제
-        CookieUtils.deleteCookie(response, "refreshToken");
 
         // tokens 데이터 삭제
         tokenService.deleteByAccessToken(accessToken);

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional
-    public ResponseEntity<UserLoginResponse> login(UserLoginRequest userLoginRequest, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<UserLoginResponse> login(UserLoginRequest userLoginRequest) {
         User user = findByEmail(userLoginRequest.getEmail()).orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_MATCH_PASSWORD));
 
         // 비밀번호 일치여부 체크
@@ -106,7 +106,7 @@ public class UserServiceImpl implements UserService {
      * 로그아웃
      */
     @Override
-    public String logout(HttpServletRequest request, HttpServletResponse response) {
+    public String logout(HttpServletRequest request) {
         // access token 가져오기
         String accessToken = jwtTokenizer.resolveAccessToken(request);
 
@@ -120,7 +120,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request) {
         // cookie에서 refresh token  가져오기
         String refreshToken = CookieUtils.findCookieValue(request, "refreshToken").orElseThrow(
                 () -> new RestApiException(CommonExceptionCode.JWT_UNKNOWN_ERROR)
@@ -183,12 +183,12 @@ public class UserServiceImpl implements UserService {
 
 
     @Transactional(readOnly = true)
-    public String sendAuthEmail(AuthEmailSendRequest emailSendRequest) {
+    public String sendAuthEmail(AuthEmailSendRequest authEmailSendRequest) {
         // 랜덤 인증 코드 생성
         String authCode = RandomAuthCode.generate();
 
         // redis에 인증 코드 저장
-        verificationService.saveCode(emailSendRequest.getEmail(), authCode);
+        verificationService.saveCode(authEmailSendRequest.getEmail(), authCode);
 
         // 메일 제목
         String subject = "[ITZIP] 이메일 인증번호 : " + authCode;
@@ -197,7 +197,7 @@ public class UserServiceImpl implements UserService {
         String body = emailService.setAuthForm(authCode);
 
         // 메일 발송
-        emailService.sendFormMail(emailSendRequest.getEmail(), subject, body);
+        emailService.sendFormMail(authEmailSendRequest.getEmail(), subject, body);
         return "인증 메일이 발송되었습니다.";
     }
 
@@ -244,8 +244,8 @@ public class UserServiceImpl implements UserService {
      * 임시 회원 탈퇴
      */
     @Override
-    public String tempUserOut(CustomUserDetails userDetails, HttpServletRequest request, HttpServletResponse response) {
-        logout(request, response);
+    public String tempUserOut(CustomUserDetails userDetails, HttpServletRequest request) {
+        logout(request);
 
         User user = findByEmail(userDetails.getEmail()).orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_FOUND_USER));
 

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -121,7 +121,6 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional(readOnly = true)
     public ResponseEntity<UserLoginResponse> refreshAccessToken(RefreshAccessTokenRequest refreshAccessTokenRequest) {
-        // cookie에서 refresh token  가져오기
         String refreshToken = refreshAccessTokenRequest.getRefreshToken();
 
         // refresh token 파싱

--- a/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/user/service/UserServiceImpl.java
@@ -120,11 +120,9 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional(readOnly = true)
-    public ResponseEntity<UserLoginResponse> refreshToken(HttpServletRequest request) {
+    public ResponseEntity<UserLoginResponse> refreshAccessToken(RefreshAccessTokenRequest refreshAccessTokenRequest) {
         // cookie에서 refresh token  가져오기
-        String refreshToken = CookieUtils.findCookieValue(request, "refreshToken").orElseThrow(
-                () -> new RestApiException(CommonExceptionCode.JWT_UNKNOWN_ERROR)
-        );
+        String refreshToken = refreshAccessTokenRequest.getRefreshToken();
 
         // refresh token 파싱
         Claims claims = jwtTokenizer.parseRefreshToken(refreshToken);

--- a/src/main/java/darkoverload/itzip/feature/user/util/CookieUtils.java
+++ b/src/main/java/darkoverload/itzip/feature/user/util/CookieUtils.java
@@ -7,6 +7,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * 쿠키를 관리하기 위한 유틸리티
+ *
+ * @deprecated jwt 인증 방식 변경(쿠키 -> 헤더)으로 인한 미사용처리
+ */
 public class CookieUtils {
 
     /**

--- a/src/main/java/darkoverload/itzip/global/config/response/exception/CustomErrorController.java
+++ b/src/main/java/darkoverload/itzip/global/config/response/exception/CustomErrorController.java
@@ -18,13 +18,15 @@ public class CustomErrorController implements ErrorController {
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
 
         return switch (status.toString()) {
+            case "403" -> // 로그인 유저의 비로그인 유저 허용 페이지 접근 예외처리
+                    ExceptionHandlerUtil.handleExceptionInternal(CommonExceptionCode.FORBIDDEN);
             case "404" -> // NoHandlerFoundException 예외처리
                     ExceptionHandlerUtil.handleExceptionInternal(CommonExceptionCode.NOT_FOUND);
             case "405" -> // HttpRequestMethodNotSupportedException 예외처리
                     ExceptionHandlerUtil.handleExceptionInternal(CommonExceptionCode.METHOD_NOT_ALLOWED);
             case "415" -> // HttpMediaTypeNotSupportedException 예외처리
                     ExceptionHandlerUtil.handleExceptionInternal(CommonExceptionCode.FILED_ERROR);
-            default -> // 404, 405에도 안잡히면 예상치 못한 예외처리
+            default -> // 예상치 못한 예외처리
                     ExceptionHandlerUtil.handleExceptionInternal(CommonExceptionCode.INTERNAL_SERVER_ERROR);
         };
     }

--- a/src/main/java/darkoverload/itzip/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/darkoverload/itzip/global/config/swagger/SwaggerConfig.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.OperationCustomizer;
@@ -26,7 +27,7 @@ import java.util.Optional;
 @Configuration
 @SecurityScheme(
         //보안 스키마 이름
-        name = "Cookie Token",
+        name = "Bearer Authentication",
         //인증 방식
         scheme = "bearer",
         //보안 유형
@@ -77,6 +78,9 @@ public class SwaggerConfig {
                     break; // 필요한 어노테이션을 찾았으면 반복을 종료
                 }
             }
+
+            // Authorize 버튼을 통해 Bearer Authentication(jwt 헤더) 설정
+            operation.addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"));
 
             return operation;
         };

--- a/src/main/resources/static/swagger-ui/index.html
+++ b/src/main/resources/static/swagger-ui/index.html
@@ -50,7 +50,7 @@
         let inputField = authModal.querySelector('input[type="text"]'); // 토큰 입력 필드 선택
         let token = inputField.value.replace('Bearer ', ''); //토큰의 Bearer 문자열 제거
         document.cookie = `accessToken=${token};path=/;SameSite=Lax;`; // 쿠키에 토큰 저장
-        alert(`JWT 토큰이 쿠키에 설정되었습니다. accessToken=${token}`); // 사용자에게 알림
+        alert(`요청 헤더에 JWT 인증을 설정했습니다. Authorization: Bearer ${token}`); // 사용자에게 알림
       }
     }
   </script>


### PR DESCRIPTION
1. 로그인/로그아웃 시 jwt를 쿠키에 저장/삭제하는 로직 삭제
2. 로그인 인증/로그아웃 시 jwt 가져오는 방식 쿠키 -> 헤더로 변경
3. 로그인 유저의 비로그인 유저 허용 페이지 접근 예외처리
4. 엑세스 토큰 재발급 시 리프레시 토큰 가져오는 방식 쿠키 -> request body로 변경
5. swagger ui에서 요청 헤더에 jwt 인증을 설정할 수 있도록 수정