### PR TITLE
☔️  테스트 추가 : 테스트 코드 및 도메인 객체 생성 로직 유닛 테스트 작성

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/request/PostCommentCreateRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/request/PostCommentCreateRequest.java
@@ -2,8 +2,12 @@ package darkoverload.itzip.feature.techinfo.controller.post.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
-@Schema(description = "기술 정보 게시글 댓글 작성 요청")
+@Schema(
+        description = "기술 정보 게시글 댓글 작성 요청"
+)
+@Builder
 public record PostCommentCreateRequest(
         @Schema(description = "게시글 ID", example = "66e724e50000000000db4e53")
         @NotBlank(message = "게시글 ID는 필수입니다.")

--- a/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/request/PostCreateRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/request/PostCreateRequest.java
@@ -2,11 +2,14 @@ package darkoverload.itzip.feature.techinfo.controller.post.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
 import java.util.List;
 
 @Schema(
         description = "기술 정보 포스트 생성 요청"
 )
+@Builder
 public record PostCreateRequest(
         @Schema(description = "카테고리 ID", example = "66ce18d84cb7d0b29ce602f5")
         @NotBlank(message = "카테고리 ID는 필수입니다.")

--- a/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/response/PostCommentResponse.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/response/PostCommentResponse.java
@@ -26,13 +26,13 @@ public record PostCommentResponse(
 ) {
 
     public static PostCommentResponse from(CommentDetails commentDetails) {
-        return new PostCommentResponse(
-                commentDetails.getCommentId(),
-                commentDetails.getProfileImagePath(),
-                commentDetails.getNickname(),
-                commentDetails.getContent(),
-                commentDetails.getCreateDate().toString()
-        );
+        return PostCommentResponse.builder()
+                .commentId(commentDetails.getCommentId())
+                .profileImagePath(commentDetails.getProfileImagePath())
+                .nickname(commentDetails.getNickname())
+                .content(commentDetails.getContent())
+                .createDate(commentDetails.getCreateDate().toString())
+                .build();
     }
 
 }

--- a/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/response/PostPreviewResponse.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/controller/post/response/PostPreviewResponse.java
@@ -1,6 +1,6 @@
 package darkoverload.itzip.feature.techinfo.controller.post.response;
 
-import darkoverload.itzip.feature.techinfo.domain.post.PostDetails;
+import darkoverload.itzip.feature.techinfo.domain.post.PostInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -48,17 +48,17 @@ public record PostPreviewResponse(
         String createDate
 ) {
 
-    public static PostPreviewResponse from(PostDetails postDetails) {
+    public static PostPreviewResponse from(PostInfo postInfo) {
         return PostPreviewResponse.builder()
-                .postId(postDetails.getPostId())
-                .categoryId(postDetails.getCategoryId())
-                .title(postDetails.getTitle())
-                .content(postDetails.getContent())
-                .thumbnailImagePath(postDetails.getThumbnailImagePath())
-                .likeCount(postDetails.getLikeCount())
-                .profileImagePath(postDetails.getProfileImagePath())
-                .author(postDetails.getAuthor())
-                .createDate(postDetails.getCreateDate().toString())
+                .postId(postInfo.getPostId())
+                .categoryId(postInfo.getCategoryId())
+                .title(postInfo.getTitle())
+                .content(postInfo.getContent())
+                .thumbnailImagePath(postInfo.getThumbnailImagePath())
+                .likeCount(postInfo.getLikeCount())
+                .profileImagePath(postInfo.getProfileImagePath())
+                .author(postInfo.getAuthor())
+                .createDate(postInfo.getCreateDate().toString())
                 .build();
     }
 

--- a/src/main/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogDetails.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogDetails.java
@@ -39,7 +39,7 @@ public class BlogDetails {
      */
     public static BlogDetails from(Blog blog, List<YearlyPostStats> yearlyPostCounts) {
         return BlogDetails.builder()
-                .blogId(blog.getUser().getId())
+                .blogId(blog.getId())
                 .profileImageUrl(blog.getUser().getImageUrl())
                 .nickname(blog.getUser().getNickname())
                 .email(blog.getUser().getEmail())

--- a/src/main/java/darkoverload/itzip/feature/techinfo/domain/post/PostDetails.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/domain/post/PostDetails.java
@@ -80,6 +80,7 @@ public class PostDetails {
                 .profileImagePath(user.getImageUrl())
                 .author(user.getNickname())
                 .email(user.getEmail())
+                .blogId(post.getBlogId())
                 .postId(post.getId())
                 .categoryId(post.getCategoryId())
                 .createDate(post.getCreateDate())
@@ -91,28 +92,6 @@ public class PostDetails {
                 .contentImagePaths(post.getContentImagePaths())
                 .isLiked(liked)
                 .isScrapped(scrapped)
-                .build();
-    }
-
-    /**
-     * Post 와 User 로부터 기본 PostDetails 생성합니다.
-     * 좋아요와 스크랩 상태는 포함되지 않습니다.
-     *
-     * @param post 게시글 정보
-     * @param user 작성자 정보
-     * @return PostDetails
-     */
-    public static PostDetails from(Post post, User user) {
-        return PostDetails.builder()
-                .profileImagePath(user.getImageUrl())
-                .author(user.getNickname())
-                .postId(post.getId())
-                .categoryId(post.getCategoryId())
-                .createDate(post.getCreateDate())
-                .title(post.getTitle())
-                .content(post.getContent())
-                .thumbnailImagePath(post.getThumbnailImagePath())
-                .likeCount(post.getLikeCount())
                 .build();
     }
 

--- a/src/main/java/darkoverload/itzip/feature/techinfo/domain/post/PostInfo.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/domain/post/PostInfo.java
@@ -1,0 +1,67 @@
+package darkoverload.itzip.feature.techinfo.domain.post;
+
+import darkoverload.itzip.feature.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PostInfo {
+
+    private final String profileImagePath;
+    private final String author;
+    private final String postId;
+    private final String categoryId;
+    private final LocalDateTime createDate;
+    private final String title;
+    private final String content;
+    private final String thumbnailImagePath;
+    private final int likeCount;
+
+    @Builder
+    public PostInfo (
+            String profileImagePath,
+            String author,
+            String postId,
+            String categoryId,
+            LocalDateTime createDate,
+            String title,
+            String content,
+            String thumbnailImagePath,
+            int likeCount
+    ) {
+        this.profileImagePath = profileImagePath;
+        this.author = author;
+        this.postId = postId;
+        this.categoryId = categoryId;
+        this.createDate = createDate;
+        this.title = title;
+        this.content = content;
+        this.thumbnailImagePath = thumbnailImagePath;
+        this.likeCount = likeCount;
+    }
+
+    /**
+     * Post 와 User 로부터 기본 PostInfo 생성합니다.
+     * 좋아요와 스크랩 상태는 포함되지 않습니다.
+     *
+     * @param post 게시글 정보
+     * @param user 작성자 정보
+     * @return PostInfo
+     */
+    public static PostInfo from(Post post, User user) {
+        return PostInfo.builder()
+                .profileImagePath(user.getImageUrl())
+                .author(user.getNickname())
+                .postId(post.getId())
+                .categoryId(post.getCategoryId())
+                .createDate(post.getCreateDate())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .thumbnailImagePath(post.getThumbnailImagePath())
+                .likeCount(post.getLikeCount())
+                .build();
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/techinfo/service/post/PostReadService.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/service/post/PostReadService.java
@@ -3,6 +3,7 @@ package darkoverload.itzip.feature.techinfo.service.post;
 import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
 import darkoverload.itzip.feature.techinfo.domain.post.Post;
 import darkoverload.itzip.feature.techinfo.domain.post.PostDetails;
+import darkoverload.itzip.feature.techinfo.domain.post.PostInfo;
 import darkoverload.itzip.feature.techinfo.dto.post.YearlyPostStats;
 import darkoverload.itzip.feature.techinfo.type.SortType;
 import org.bson.types.ObjectId;
@@ -33,7 +34,7 @@ public interface PostReadService {
 
     Page<Post> getPostsByNickname(String nickname, int page, int size, SortType sortType);
 
-    Page<PostDetails> getAllOrPostsByCategoryId(String categoryId, int page, int size, SortType sortType);
+    Page<PostInfo> getAllOrPostsByCategoryId(String categoryId, int page, int size, SortType sortType);
 
     List<Post> getPostsByDateRange(Long blogId, LocalDateTime creteDate, int limit);
 

--- a/src/main/java/darkoverload/itzip/feature/techinfo/service/post/PostReadServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/techinfo/service/post/PostReadServiceImpl.java
@@ -4,6 +4,7 @@ import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
 import darkoverload.itzip.feature.techinfo.domain.blog.Blog;
 import darkoverload.itzip.feature.techinfo.domain.post.Post;
 import darkoverload.itzip.feature.techinfo.domain.post.PostDetails;
+import darkoverload.itzip.feature.techinfo.domain.post.PostInfo;
 import darkoverload.itzip.feature.techinfo.dto.post.YearlyPostStats;
 import darkoverload.itzip.feature.techinfo.service.blog.port.BlogReadRepository;
 import darkoverload.itzip.feature.techinfo.service.like.LikeService;
@@ -186,7 +187,7 @@ public class PostReadServiceImpl implements PostReadService {
      */
     @Override
     @Transactional(readOnly = true)
-    public Page<PostDetails> getAllOrPostsByCategoryId(String categoryId, int page, int size, SortType sortType) {
+    public Page<PostInfo> getAllOrPostsByCategoryId(String categoryId, int page, int size, SortType sortType) {
         Pageable pageable = PageRequest.of(page, size, SortUtil.getType(sortType));
 
         Page<Post> posts = (categoryId != null) ? this.findPostsByCategoryId(categoryId, pageable) : this.findAll(pageable);
@@ -199,7 +200,7 @@ public class PostReadServiceImpl implements PostReadService {
 
         return posts.map(post -> {
             Blog blog = blogReadRepository.getById(post.getBlogId());
-            return PostDetails.from(post, blog.getUser());
+            return PostInfo.from(post, blog.getUser());
         });
     }
 

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogDetailsTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogDetailsTest.java
@@ -1,0 +1,89 @@
+package darkoverload.itzip.feature.techinfo.domain.blog;
+
+import static java.util.Collections.EMPTY_LIST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.dto.post.MonthlyPostStats;
+import darkoverload.itzip.feature.techinfo.dto.post.WeeklyPostStats;
+import darkoverload.itzip.feature.techinfo.dto.post.YearlyPostStats;
+import darkoverload.itzip.feature.user.domain.User;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+class BlogDetailsTest {
+
+    @Test
+    void 블로그와_통계정보로_상세정보를_생성한다() {
+        // given
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .imageUrl("https://image.url")
+                .build();
+
+        Blog blog = Blog.builder()
+                .id(1L)
+                .user(user)
+                .intro("This is a blog intro.")
+                .isPublic(true)
+                .build();
+
+        YearlyPostStats yearlyPostStats = new YearlyPostStats(2024, EMPTY_LIST);
+
+        // when
+        BlogDetails result = BlogDetails.from(blog, List.of(yearlyPostStats));
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getBlogId()).isEqualTo(blog.getId());
+        assertThat(result.getProfileImageUrl()).isEqualTo(blog.getUser().getImageUrl());
+        assertThat(result.getNickname()).isEqualTo(blog.getUser().getNickname());
+        assertThat(result.getEmail()).isEqualTo(blog.getUser().getEmail());
+        assertThat(result.getIntro()).isEqualTo(blog.getIntro());
+        assertThat(result.getYearlyPostCounts().size()).isEqualTo(1);
+    }
+
+    @Test
+    void 연도별_게시글_통계가_생성된다() {
+        // given
+        WeeklyPostStats weeklyPostStats = new WeeklyPostStats(1, 1);
+        MonthlyPostStats monthlyPostStats = new MonthlyPostStats(1, List.of(weeklyPostStats));
+
+        // when
+        YearlyPostStats result = new YearlyPostStats(2024, List.of(monthlyPostStats));
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getYear()).isEqualTo(2024);
+        assertThat(result.getMonths().size()).isEqualTo(1);
+        assertThat(result.getMonths().getFirst().getMonth()).isEqualTo(1);
+    }
+
+    @Test
+    void 월별_게시글_통계가_생성된다() {
+        // given
+        WeeklyPostStats weeklyPostStats = new WeeklyPostStats(1, 5);
+
+        // when
+        MonthlyPostStats result = new MonthlyPostStats(2, List.of(weeklyPostStats));
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMonth()).isEqualTo(2);
+        assertThat(result.getWeeks().size()).isEqualTo(1);
+        assertThat(result.getWeeks().getFirst().getWeek()).isEqualTo(1);
+        assertThat(result.getWeeks().getFirst().getPostCount()).isEqualTo(5);
+    }
+
+    @Test
+    void 주차와_게시글_수량으로_주별_게시글_통계를_생성한다() {
+        // given & when
+        WeeklyPostStats result = new WeeklyPostStats(3, 10);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getWeek()).isEqualTo(3);
+        assertThat(result.getPostCount()).isEqualTo(10);
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogPostTimelineTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogPostTimelineTest.java
@@ -1,0 +1,45 @@
+package darkoverload.itzip.feature.techinfo.domain.blog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.domain.post.Post;
+import darkoverload.itzip.feature.techinfo.mock.PostMockData;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class BlogPostTimelineTest {
+
+    @Test
+    void 닉네임과_게시글_목록으로_블로그_게시글_타임라인을_생성한다() {
+        // given
+        String nickname = "techblogger";
+        Post post = PostMockData.postDataOne;
+
+        // when
+        BlogPostTimeline result = BlogPostTimeline.from(nickname, List.of(post));
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getNickname()).isEqualTo(nickname);
+        assertThat(result.getPosts().size()).isEqualTo(1);
+        assertThat(result.getPosts().getFirst().getTitle()).isEqualTo(post.getTitle());
+        assertThat(result.getPosts().getFirst().getContent()).isEqualTo(post.getContent());
+        assertThat(result.getPosts().getFirst().getIsPublic()).isTrue();
+    }
+
+    @Test
+    void 빈_목록으로_타임라인_생성시_빈_목록_반환한다() {
+        // given
+        String nickname = "emptyblogger";
+
+        // when
+        BlogPostTimeline result = BlogPostTimeline.from(nickname, List.of());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getNickname()).isEqualTo(nickname);
+        assertThat(result.getPosts()).isEmpty();
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/blog/BlogTest.java
@@ -1,0 +1,75 @@
+package darkoverload.itzip.feature.techinfo.domain.blog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+public class BlogTest {
+
+    @Test
+    void 블로그_생성_시_모든_필드가_올바르게_매핑된다() {
+        // given
+        Long blogId = 1L;
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .build();
+        String intro = "This is a sample blog";
+        boolean isPublic = true;
+
+        // when
+        Blog result = Blog.builder()
+                .id(blogId)
+                .user(user)
+                .intro(intro)
+                .isPublic(isPublic)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(blogId);
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getIntro()).isEqualTo(intro);
+        assertThat(result.isPublic()).isEqualTo(isPublic);
+    }
+
+    @Test
+    void 사용자로부터_블로그_생성_시_기본적으로_공개상태이다() {
+        // given
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .build();
+
+        // when
+        Blog blog = Blog.from(user);
+
+        // then
+        assertThat(blog).isNotNull();
+        assertThat(blog.getUser()).isEqualTo(user);
+        assertThat(blog.isPublic()).isTrue();
+    }
+
+    @Test
+    void 블로그가_비공개로_설정되면_isPublic이_false를_반환한다() {
+        // given
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .build();
+
+        // when
+        Blog result = Blog.builder()
+                .id(2L)
+                .user(user)
+                .intro("This is a sample blog")
+                .isPublic(false)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isPublic()).isFalse();
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/comment/CommentDetailsTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/comment/CommentDetailsTest.java
@@ -1,0 +1,41 @@
+package darkoverload.itzip.feature.techinfo.domain.comment;
+
+import darkoverload.itzip.feature.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentDetailsTest {
+
+    @Test
+    void 댓글과_작성자_정보로_상세_정보를_생성한다() {
+        // given
+        Comment comment = Comment.builder()
+                .id("675979e6605cda1eaf5d4c19")
+                .postId("675979e6605cda1eaf5d4c17")
+                .userId(100L)
+                .content("This is a test comment.")
+                .isPublic(true)
+                .createDate(LocalDateTime.now())
+                .build();
+
+        User user = User.builder()
+                .nickname("test_user")
+                .imageUrl("/images/profile.jpg")
+                .build();
+
+        // when
+        CommentDetails result = CommentDetails.from(comment, user);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getCommentId()).isEqualTo(comment.getId());
+        assertThat(result.getProfileImagePath()).isEqualTo(user.getImageUrl());
+        assertThat(result.getNickname()).isEqualTo(user.getNickname());
+        assertThat(result.getContent()).isEqualTo(comment.getContent());
+        assertThat(result.getCreateDate()).isEqualTo(comment.getCreateDate());
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/comment/CommentTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/comment/CommentTest.java
@@ -1,0 +1,61 @@
+package darkoverload.itzip.feature.techinfo.domain.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.controller.post.request.PostCommentCreateRequest;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+
+class CommentTest {
+
+    @Test
+    void 댓글_생성_시_모든_필드가_올바르게_매핑된다() {
+        // given
+        String id = "675979e6605cda1eaf5d4c19";
+        String postId = "675979e6605cda1eaf5d4c17";
+        Long userId = 103L;
+        String content = "test";
+        Boolean isPublic = true;
+        LocalDateTime createDate = LocalDateTime.now();
+
+        // when
+        Comment result = Comment.builder()
+                .id(id)
+                .postId(postId)
+                .userId(userId)
+                .content(content)
+                .isPublic(isPublic)
+                .createDate(createDate)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getPostId()).isEqualTo(postId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getIsPublic()).isEqualTo(isPublic);
+        assertThat(result.getCreateDate()).isEqualTo(createDate);
+    }
+
+    @Test
+    void 댓글_작성_요청_시_새로운_댓글을_생성한다() {
+        // given
+        Long userId = 100L;
+
+        PostCommentCreateRequest request = PostCommentCreateRequest.builder()
+                .postId("675979e6605cda1eaf5d4c17")
+                .content("This is a comment")
+                .build();
+
+        // when
+        Comment result = Comment.from(request, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.getPostId()).isEqualTo(request.postId());
+        assertThat(result.getContent()).isEqualTo(request.content());
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/like/LikeTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/like/LikeTest.java
@@ -1,0 +1,49 @@
+package darkoverload.itzip.feature.techinfo.domain.like;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.dto.like.LikeStatus;
+import org.junit.jupiter.api.Test;
+
+class LikeTest {
+
+    @Test
+    void 좋아요_생성_시_모든_필드가_올바르게_매핑된다() {
+        // given
+        String id = "675979e6605cda1eaf5d4c20";
+        String postId = "675979e6605cda1eaf5d4c17";
+        Long userId = 100L;
+
+        // when
+        Like result = Like.builder()
+                .id(id)
+                .postId(postId)
+                .userId(userId)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getPostId()).isEqualTo(postId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void 좋아요_상태로부터_좋아요를_생성한다() {
+        // given
+        LikeStatus likeStatus = LikeStatus.builder()
+                .postId("675979e6605cda1eaf5d4c17")
+                .userId(100L)
+                .isLiked(true)
+                .build();
+
+        // when
+        Like result = Like.from(likeStatus);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getPostId()).isEqualTo(likeStatus.getPostId());
+        assertThat(result.getUserId()).isEqualTo(likeStatus.getUserId());
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostDetailsTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostDetailsTest.java
@@ -1,0 +1,45 @@
+package darkoverload.itzip.feature.techinfo.domain.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.mock.PostMockData;
+import darkoverload.itzip.feature.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+class PostDetailsTest {
+
+    @Test
+    void 게시글과_작성자_정보로_상세_정보가_생성된다() {
+        // given
+        Post post = PostMockData.postDataOne;
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .build();
+
+        boolean liked = true;
+        boolean scrapped = false;
+
+        // when
+        PostDetails result = PostDetails.from(post, user, liked, scrapped);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getProfileImagePath()).isEqualTo(user.getImageUrl());
+        assertThat(result.getAuthor()).isEqualTo(user.getNickname());
+        assertThat(result.getBlogId()).isEqualTo(post.getBlogId());
+        assertThat(result.getPostId()).isEqualTo(post.getId());
+        assertThat(result.getCategoryId()).isEqualTo(post.getCategoryId());
+        assertThat(result.getCreateDate()).isEqualTo(post.getCreateDate());
+        assertThat(result.getTitle()).isEqualTo(post.getTitle());
+        assertThat(result.getContent()).isEqualTo(post.getContent());
+        assertThat(result.getViewCount()).isEqualTo(post.getViewCount());
+        assertThat(result.getLikeCount()).isEqualTo(post.getLikeCount());
+        assertThat(result.getThumbnailImagePath()).isEqualTo(post.getThumbnailImagePath());
+        assertThat(result.getContentImagePaths()).isEqualTo(post.getContentImagePaths());
+        assertThat(result.isLiked()).isEqualTo(liked);
+        assertThat(result.isScrapped()).isEqualTo(scrapped);
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostInfoTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostInfoTest.java
@@ -1,0 +1,37 @@
+package darkoverload.itzip.feature.techinfo.domain.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.mock.PostMockData;
+import darkoverload.itzip.feature.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+class PostInfoTest {
+
+    @Test
+    void 게시글과_작성자_정보로_기본_정보가_생성된다() {
+        // given
+        Post post = PostMockData.postDataOne;
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .build();
+
+        // when
+        PostInfo result = PostInfo.from(post, user);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getProfileImagePath()).isEqualTo(user.getImageUrl());
+        assertThat(result.getAuthor()).isEqualTo(user.getNickname());
+        assertThat(result.getPostId()).isEqualTo(post.getId());
+        assertThat(result.getCategoryId()).isEqualTo(post.getCategoryId());
+        assertThat(result.getCreateDate()).isEqualTo(post.getCreateDate());
+        assertThat(result.getTitle()).isEqualTo(post.getTitle());
+        assertThat(result.getContent()).isEqualTo(post.getContent());
+        assertThat(result.getLikeCount()).isEqualTo(post.getLikeCount());
+        assertThat(result.getThumbnailImagePath()).isEqualTo(post.getThumbnailImagePath());
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/post/PostTest.java
@@ -1,0 +1,88 @@
+package darkoverload.itzip.feature.techinfo.domain.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.controller.post.request.PostCreateRequest;
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import java.util.List;
+
+class PostTest {
+
+    @Test
+    void 게시글_생성_시_모든_필드가_올바르게_매핑된다() {
+        // given
+        String id = "675979e6605cda1eaf5d4c17";
+        Long blogId = 1L;
+        String categoryId = "66ce18d84cb7d0b29ce602f5";
+        String title = "밤하늘 아래, 감정의 여정";
+        String content = "세 개의 이미지는 감정의 여정을 표현한다.";
+        Integer viewCount = 0;
+        Integer likeCount = 0;
+        boolean isPublic = true;
+        LocalDateTime createDate = LocalDateTime.now();
+        String thumbnailImagePath = "/images/thumbnail.jpg";
+        List<String> contentImagePaths = List.of(
+                "/images/content1.jpg",
+                "/images/content2.jpg"
+        );
+
+        // when
+        Post result = Post.builder()
+                .id(id)
+                .blogId(blogId)
+                .categoryId(categoryId)
+                .title(title)
+                .content(content)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .isPublic(isPublic)
+                .createDate(createDate)
+                .thumbnailImagePath(thumbnailImagePath)
+                .contentImagePaths(contentImagePaths)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getBlogId()).isEqualTo(blogId);
+        assertThat(result.getCategoryId()).isEqualTo(categoryId);
+        assertThat(result.getTitle()).isEqualTo(title);
+        assertThat(result.getContent()).isEqualTo(content);
+        assertThat(result.getViewCount()).isEqualTo(viewCount);
+        assertThat(result.getLikeCount()).isEqualTo(likeCount);
+        assertThat(result.getIsPublic()).isTrue();
+        assertThat(result.getCreateDate()).isEqualTo(createDate);
+        assertThat(result.getThumbnailImagePath()).isEqualTo(thumbnailImagePath);
+        assertThat(result.getContentImagePaths()).isEqualTo(contentImagePaths);
+    }
+
+    @Test
+    void 게시글_작성_요청으로_새로운_게시글을_생성한다() {
+        // given
+        Long blogId = 1L;
+        PostCreateRequest request = PostCreateRequest.builder()
+                .categoryId("66ce18d84cb7d0b29ce602f5")
+                .title("밤하늘 아래, 감정의 여정")
+                .content("세 개의 이미지는 감정의 여정을 표현한다.")
+                .thumbnailImagePath("/images/thumbnail.jpg")
+                .contentImagePaths(List.of(
+                        "/images/content1.jpg",
+                        "/images/content2.jpg"
+                ))
+                .build();
+
+        // when
+        Post result = Post.from(request, blogId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getBlogId()).isEqualTo(blogId);
+        assertThat(result.getCategoryId()).isEqualTo(request.categoryId());
+        assertThat(result.getTitle()).isEqualTo(request.title());
+        assertThat(result.getContent()).isEqualTo(request.content());
+        assertThat(result.getThumbnailImagePath()).isEqualTo(request.thumbnailImagePath());
+        assertThat(result.getContentImagePaths()).isEqualTo(request.contentImagePaths());
+    }
+
+}

--- a/src/test/java/darkoverload/itzip/feature/techinfo/domain/scrap/ScrapTest.java
+++ b/src/test/java/darkoverload/itzip/feature/techinfo/domain/scrap/ScrapTest.java
@@ -1,0 +1,49 @@
+package darkoverload.itzip.feature.techinfo.domain.scrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import darkoverload.itzip.feature.techinfo.dto.scrap.ScrapStatus;
+import org.junit.jupiter.api.Test;
+
+class ScrapTest {
+
+    @Test
+    void 스크랩_생성_시_모든_필드가_올바르게_매핑된다() {
+        // given
+        String id = "675979e6605cda1eaf5d4c20";
+        String postId = "675979e6605cda1eaf5d4c17";
+        Long userId = 100L;
+
+        // when
+        Scrap result = Scrap.builder()
+                .id(id)
+                .postId(postId)
+                .userId(userId)
+                .build();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(id);
+        assertThat(result.getPostId()).isEqualTo(postId);
+        assertThat(result.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void 스크랩_상태로부터_스크랩을_생성한다() {
+        // given
+        ScrapStatus scrapStatus = ScrapStatus.builder()
+                .postId("675979e6605cda1eaf5d4c17")
+                .userId(100L)
+                .isScrapped(true)
+                .build();
+
+        // when
+        Scrap result = Scrap.from(scrapStatus);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getPostId()).isEqualTo(scrapStatus.getPostId());
+        assertThat(result.getUserId()).isEqualTo(scrapStatus.getUserId());
+    }
+
+}


### PR DESCRIPTION
## ✨ 변경 사항  
이번 PR은 도메인 객체의 생성 로직에 대한 유닛 테스트를 추가하여 시스템의 안정성을 높이고, 리팩토링 및 기능 확장 시 리그레션을 방지하기 위한 목적을 가집니다. 아래와 같은 도메인에 대해 테스트가 추가되었습니다.

---

## 🔍 주요 변경 내용  
1. **`Blog` 도메인 테스트 추가**  
   - 블로그 생성 시 모든 필드 매핑 검증  
   - 기본 공개 상태 여부 확인  

2. **`BlogDetails` 도메인 테스트 추가**  
   - 블로그와 통계 정보로부터 상세 정보를 생성하는 로직 검증  

3. **`BlogPostTimeline` 도메인 테스트 추가**  
   - 닉네임 및 게시글 목록을 기반으로 타임라인 생성 검증  

4. **`Comment` 및 `CommentDetails` 도메인 테스트 추가**  
   - 댓글 생성 시 필드 매핑 확인  
   - 작성자와 댓글 정보로 상세 정보를 생성하는 로직 검증  

5. **`Like` 도메인 테스트 추가**  
   - 좋아요 생성 시 필드 매핑 확인  
   - `LikeStatus`를 기반으로 좋아요 객체 생성 로직 검증  

6. **`Post` 및 `PostDetails` 도메인 테스트 추가**  
   - 게시글 생성 시 필드 매핑 검증  
   - 작성 요청(`PostCreateRequest`) 및 작성자 정보를 기반으로 게시글 생성 검증  
   - 상세 정보 생성 로직(`PostDetails.from`)의 매핑 검증  

7. **`Scrap` 도메인 테스트 추가**  
   - 스크랩 생성 시 필드 매핑 확인  
   - `ScrapStatus`를 기반으로 스크랩 객체 생성 로직 검증  