### PR TITLE
✨ 새 기능 : 닉네임 정규식 구현

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/user/controller/MypageController.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/MypageController.java
@@ -13,10 +13,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,7 +40,14 @@ public class MypageController {
     @ResponseCodeAnnotation(CommonResponseCode.SUCCESS)
     @ExceptionCodeAnnotations({CommonExceptionCode.FILED_ERROR})
     public String checkDuplicateNickname(
-            @Parameter(description = "사용할 닉네임") @RequestParam @NotBlank String nickname
+            @Parameter(description = "사용할 닉네임")
+            @RequestParam
+            @NotBlank
+            @Pattern(
+                    regexp = "^(?=.*[가-힣a-zA-Z])[가-힣a-zA-Z0-9 _-]{2,16}$",
+                    message = "올바르지 않은 닉네임 형식입니다."
+            )
+            String nickname
     ) {
         return mypageService.checkDuplicateNickname(nickname);
     }

--- a/src/main/java/darkoverload/itzip/feature/user/controller/request/ChangeNicknameRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/user/controller/request/ChangeNicknameRequest.java
@@ -2,6 +2,7 @@ package darkoverload.itzip.feature.user.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChangeNicknameRequest {
     @NotEmpty(message = "닉네임을 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[가-힣a-zA-Z])[가-힣a-zA-Z0-9 _-]{2,16}$",
+            message = "올바르지 않은 닉네임 형식입니다.")
     @Schema(description = "닉네임", example = "뛰어난 1번째 사자")
     private String nickname;
 }


### PR DESCRIPTION
닉네임의 규칙을 정하여 닉네임 변경, 중복체크 시 정규식으로 검증하는 로직 구현

닉네임 규칙: 한글이나 영어를 포함한 2~16글자 범위의 문자열 특수문자는 띄어쓰기, "-", "_" 허용

Resolves: #151