### PR TITLE
♻️ 코드 리팩토링 : 퀴즈 점수 및 랭킹 기능 추가와 관련 예외 처리 및 버그 수정

### DIFF
--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/CsQuizzesController.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/CsQuizzesController.java
@@ -4,6 +4,7 @@ import darkoverload.itzip.feature.csQuiz.controller.request.QuizQueryRequest;
 import darkoverload.itzip.feature.csQuiz.entity.SortBy;
 import darkoverload.itzip.feature.csQuiz.controller.response.QuizDetailResponse;
 import darkoverload.itzip.feature.csQuiz.service.QuizService;
+import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
 import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
 import darkoverload.itzip.global.config.response.code.CommonResponseCode;
 import darkoverload.itzip.global.config.swagger.ExceptionCodeAnnotations;
@@ -14,8 +15,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.PagedModel;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 
 //퀴즈(복수) 관련 엔드포인트 모음
 @Tag(name = "Computer Science Quiz", description = "퀴즈(복수) 관련 엔드포인트 모음")
@@ -31,7 +32,6 @@ public class CsQuizzesController {
      * @param difficulty   퀴즈 난이도 (선택 사항)
      * @param categoryId   카테고리 ID (선택 사항)
      * @param sortBy       정렬 기준 (기본값: NEWEST)
-     * @param userId       사용자 ID (기본값: 0)
      * @param inUserSolved 사용자가 푼 퀴즈 포함 여부 (기본값: false)
      * @param page         페이지 번호 (기본값: 0)
      * @param size         페이지 크기 (기본값: 10)
@@ -46,19 +46,20 @@ public class CsQuizzesController {
     @ExceptionCodeAnnotations({CommonExceptionCode.NOT_FOUND_USER})
     @GetMapping("/search")
     public PagedModel<EntityModel<QuizDetailResponse>> getFilteredAndSortedQuizzes(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "퀴즈 난이도 입력칸 1~3") @RequestParam(required = false) Integer difficulty,
             @Parameter(description = "카테고리 식별값 입력칸") @RequestParam(required = false) Long categoryId,
             @Parameter(description = "NEWEST 새로운 순, OLDEST 오래된 순, RECOMMENED 추천순 아무것도 없으면 새로운순") @RequestParam(required = false, defaultValue = "NEWEST") SortBy sortBy,
-            @Parameter(description = "사용자 ID") @RequestParam(required = false) Long userId,
             @Parameter(description = "사용자가 푼 문제를 포함 하는지 true면 포함 false면 미포함") @RequestParam(required = false, defaultValue = "false") boolean inUserSolved,
             @Parameter(description = "문제 페이지 0부터 시작") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "가져올 문제 수") @RequestParam(defaultValue = "10") int size,
-            @Parameter(description = "검색할 단어") @RequestParam(required = false) String keyword) {
+            @Parameter(description = "검색할 단어") @RequestParam(required = false) String keyword
+    ) {
         QuizQueryRequest quizQueryRequest = QuizQueryRequest.builder()
                 .difficulty(difficulty)
                 .categoryId(categoryId)
                 .sortBy(sortBy)
-                .userId(userId)
+                .email(userDetails.getEmail())
                 .inUserSolved(inUserSolved)
                 .page(page)
                 .size(size)

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/request/QuizQueryRequest.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/request/QuizQueryRequest.java
@@ -15,7 +15,7 @@ public class QuizQueryRequest {
     //NEWEST, OLDEST
     private SortBy sortBy;
     //사용자 ID
-    private Long userId;
+    private String email;
     //사용자가 푼문제를 포함하는지 ture면 포함 false면 미포함
     private boolean inUserSolved;
     //문제 페이지 0부터 시작

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizRankingResponse.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizRankingResponse.java
@@ -1,0 +1,30 @@
+package darkoverload.itzip.feature.csQuiz.controller.response;
+
+import darkoverload.itzip.feature.csQuiz.entity.QuizRanking;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "퀴즈 랭킹 응답 DTO로 사용자의 순위, 이름, 그리고 점수를 포함합니다.")
+public class QuizRankingResponse {
+
+    @Schema(description = "사용자의 순위", example = "1")
+    private final int rank;
+
+    @Schema(description = "사용자 이름", example = "홍길동")
+    private final String name;
+
+    @Schema(description = "퀴즈 점수", example = "100")
+    private final int score;
+
+    public QuizRankingResponse(final int rank, final String name, final int score) {
+        this.rank = rank;
+        this.name = name;
+        this.score = score;
+    }
+
+    public static QuizRankingResponse from(final QuizRanking ranking) {
+        return new QuizRankingResponse(ranking.getRank(), ranking.getName(), ranking.getScore());
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizRankingResponses.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizRankingResponses.java
@@ -1,0 +1,21 @@
+package darkoverload.itzip.feature.csQuiz.controller.response;
+
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class QuizRankingResponses {
+
+    private final List<QuizRankingResponse> responses;
+
+    private QuizRankingResponses(final List<QuizRankingResponse> responses) {
+        this.responses = Collections.unmodifiableList(responses);
+    }
+
+    public static QuizRankingResponses of(final List<QuizRankingResponse> responses) {
+        return new QuizRankingResponses(responses);
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizScoreResponse.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/controller/response/QuizScoreResponse.java
@@ -1,0 +1,26 @@
+package darkoverload.itzip.feature.csQuiz.controller.response;
+
+import darkoverload.itzip.feature.csQuiz.entity.QuizScore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "퀴즈 점수 응답 DTO로 해당 객체는 사용자의 닉네임과 현재 퀴즈 점수를 포함합니다.")
+public class QuizScoreResponse {
+
+    @Schema(description = "사용자 닉네임", example = "홍길동")
+    private final String name;
+
+    @Schema(description = "사용자의 퀴즈 점수", example = "120")
+    private final int score;
+
+    public QuizScoreResponse(final String name, final int score) {
+        this.name = name;
+        this.score = score;
+    }
+
+    public static QuizScoreResponse from(final QuizScore score) {
+        return new QuizScoreResponse(score.getUser().getNickname(), score.getScore());
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizRanking.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizRanking.java
@@ -1,0 +1,33 @@
+package darkoverload.itzip.feature.csQuiz.entity;
+
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+public class QuizRanking {
+
+    private final int rank;
+    private final String name;
+    private final int score;
+
+    private QuizRanking(final int rank, final String name, final int score) {
+        checkNameNotNull(name);
+        this.rank = rank;
+        this.name = name;
+        this.score = score;
+    }
+
+    private void checkNameNotNull(final String name) {
+        if (Objects.isNull(name)) {
+            throw new RestApiException(CommonExceptionCode.QUIZ_PROCESSING_ERROR);
+        }
+    }
+
+    public static QuizRanking create(final int rank, final QuizScore score) {
+        return new QuizRanking(rank, score.getUser().getNickname(), score.getScore());
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizRankings.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizRankings.java
@@ -1,0 +1,22 @@
+package darkoverload.itzip.feature.csQuiz.entity;
+
+import java.util.Collections;
+import java.util.List;
+
+public class QuizRankings {
+
+    private final List<QuizRanking> rankings;
+
+    private QuizRankings(final List<QuizRanking> rankings) {
+        this.rankings = Collections.unmodifiableList(rankings);
+    }
+
+    public static QuizRankings of(final List<QuizRanking> rankings) {
+        return new QuizRankings(rankings);
+    }
+
+    public List<QuizRanking> getRankings() {
+        return rankings;
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizScore.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/entity/QuizScore.java
@@ -1,0 +1,49 @@
+package darkoverload.itzip.feature.csQuiz.entity;
+
+import darkoverload.itzip.feature.user.entity.UserEntity;
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@Entity
+@Table(name = "quiz_scores")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuizScore {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+    private Integer score;
+
+    private QuizScore(final UserEntity user) {
+        notNullParameters(user);
+        this.user = user;
+        this.score = 0;
+    }
+
+    private void notNullParameters(final UserEntity user) {
+        if (Objects.isNull(user)) {
+            throw new RestApiException(CommonExceptionCode.QUIZ_PROCESSING_ERROR);
+        }
+    }
+
+    public static QuizScore create(final UserEntity user) {
+        return new QuizScore(user);
+    }
+
+    public void incrementScore(final Integer score) {
+        this.score += score;
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/repository/quizscore/QuizScoreRepository.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/repository/quizscore/QuizScoreRepository.java
@@ -1,0 +1,13 @@
+package darkoverload.itzip.feature.csQuiz.repository.quizscore;
+
+import darkoverload.itzip.feature.csQuiz.entity.QuizScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuizScoreRepository extends JpaRepository<QuizScore, Long> {
+
+    Optional<List<QuizScore>> findTop6ByOrderByScoreDesc();
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/QuizService.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/QuizService.java
@@ -3,7 +3,7 @@ package darkoverload.itzip.feature.csQuiz.service;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.CheckAnswer;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.CreateQuiz;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.GivenPointToQuiz;
-import darkoverload.itzip.feature.csQuiz.service.sub.quizCategory.FindQuizCategory;
+import darkoverload.itzip.feature.csQuiz.service.sub.quizcategory.FindQuizCategory;
 import darkoverload.itzip.feature.csQuiz.service.sub.quizzes.FindQiuzQuery;
 
 //컨트롤러가 사용할 service계층 진입점 상속을 통해서 서브 시스템들을 받아온다.

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/QuizServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/QuizServiceImpl.java
@@ -8,11 +8,10 @@ import darkoverload.itzip.feature.csQuiz.controller.response.QuizCategoryDetailR
 import darkoverload.itzip.feature.csQuiz.controller.response.QuizDetailResponse;
 import darkoverload.itzip.feature.csQuiz.entity.QuizCategory;
 import darkoverload.itzip.feature.csQuiz.entity.UserQuizStatus;
-import darkoverload.itzip.feature.csQuiz.repository.quiz.QuizRepository;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.CheckAnswer;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.CreateQuiz;
 import darkoverload.itzip.feature.csQuiz.service.sub.quiz.GivenPointToQuiz;
-import darkoverload.itzip.feature.csQuiz.service.sub.quizCategory.FindQuizCategory;
+import darkoverload.itzip.feature.csQuiz.service.sub.quizcategory.FindQuizCategory;
 import darkoverload.itzip.feature.csQuiz.service.sub.quizzes.FindQiuzQuery;
 import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +41,6 @@ public class QuizServiceImpl implements QuizService {
 
     @Qualifier("createQuizImpl")
     private final CreateQuiz createQuiz;
-    private final QuizRepository quizRepository;
 
     /**
      * 주어진 필터와 정렬 기준, 사용자 정보를 기반으로 퀴즈 목록을 조회하는 메서드

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizcategory/FindQuizCategory.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizcategory/FindQuizCategory.java
@@ -1,4 +1,4 @@
-package darkoverload.itzip.feature.csQuiz.service.sub.quizCategory;
+package darkoverload.itzip.feature.csQuiz.service.sub.quizcategory;
 
 import darkoverload.itzip.feature.csQuiz.controller.response.QuizCategoryDetailResponse;
 import darkoverload.itzip.feature.csQuiz.entity.QuizCategory;

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizcategory/FindQuizCategoryImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizcategory/FindQuizCategoryImpl.java
@@ -1,4 +1,4 @@
-package darkoverload.itzip.feature.csQuiz.service.sub.quizCategory;
+package darkoverload.itzip.feature.csQuiz.service.sub.quizcategory;
 
 import darkoverload.itzip.feature.csQuiz.controller.response.QuizCategoryDetailResponse;
 import darkoverload.itzip.feature.csQuiz.entity.QuizCategory;

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizscore/QuizScoreService.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizscore/QuizScoreService.java
@@ -1,0 +1,13 @@
+package darkoverload.itzip.feature.csQuiz.service.sub.quizscore;
+
+import darkoverload.itzip.feature.csQuiz.entity.QuizRankings;
+import darkoverload.itzip.feature.csQuiz.entity.QuizScore;
+import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
+
+public interface QuizScoreService {
+
+    QuizScore findQuizScoreById(CustomUserDetails userDetails);
+
+    QuizRankings getTop6Ranking();
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizscore/QuizScoreServiceImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizscore/QuizScoreServiceImpl.java
@@ -1,0 +1,54 @@
+package darkoverload.itzip.feature.csQuiz.service.sub.quizscore;
+
+import darkoverload.itzip.feature.csQuiz.entity.QuizRanking;
+import darkoverload.itzip.feature.csQuiz.entity.QuizRankings;
+import darkoverload.itzip.feature.csQuiz.entity.QuizScore;
+import darkoverload.itzip.feature.csQuiz.repository.quizscore.QuizScoreRepository;
+import darkoverload.itzip.feature.jwt.infrastructure.CustomUserDetails;
+import darkoverload.itzip.feature.user.domain.User;
+import darkoverload.itzip.feature.user.entity.UserEntity;
+import darkoverload.itzip.feature.user.service.UserService;
+import darkoverload.itzip.global.config.response.code.CommonExceptionCode;
+import darkoverload.itzip.global.config.response.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizScoreServiceImpl implements QuizScoreService {
+
+    private final UserService userService;
+
+    private final QuizScoreRepository quizScoreRepository;
+
+    @Override
+    public QuizScore findQuizScoreById(CustomUserDetails userDetails) {
+        final UserEntity user = userService.findByEmail(userDetails.getEmail())
+                .map(User::convertToEntity)
+                .orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_FOUND_USER));
+
+        return quizScoreRepository.findById(user.getId())
+                .orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_FOUND_QUIZ_SCORE));
+    }
+
+    @Override
+    public QuizRankings getTop6Ranking() {
+        final List<QuizScore> scores = quizScoreRepository.findTop6ByOrderByScoreDesc()
+                .orElseThrow(() -> new RestApiException(CommonExceptionCode.NOT_FOUND_QUIZ_SCORE_RANKING));
+
+        final List<QuizRanking> rankings = new ArrayList<>();
+        int rank = 1;
+        for (QuizScore score : scores) {
+            rankings.add(QuizRanking.create(rank, score));
+            rank++;
+        }
+
+        return QuizRankings.of(rankings);
+    }
+
+}

--- a/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizzes/FindQuizQuerytImpl.java
+++ b/src/main/java/darkoverload/itzip/feature/csQuiz/service/sub/quizzes/FindQuizQuerytImpl.java
@@ -51,9 +51,9 @@ public class FindQuizQuerytImpl implements FindQiuzQuery {
         // 사용자가 푼 문제의 Id값들만 저장할 리스트 초기화
         List<String> solvedProblemIds = new ArrayList<>();
 
-        if (quizQueryRequest.getUserId() != null){
+        if (quizQueryRequest.isInUserSolved() != true && quizQueryRequest.getEmail() != null) {
             //사용자를 찾고 사용자가 없을시 사용자가 없음 예외 출력
-            UserEntity userEntity = userService.getById(quizQueryRequest.getUserId())
+            UserEntity userEntity = userService.getByEmail(quizQueryRequest.getEmail())
                     .convertToEntity();
 
             //사용자가 푼문제매핑 테이블 list로 받아옴

--- a/src/main/java/darkoverload/itzip/global/config/response/code/CommonExceptionCode.java
+++ b/src/main/java/darkoverload/itzip/global/config/response/code/CommonExceptionCode.java
@@ -130,6 +130,14 @@ public enum CommonExceptionCode implements ResponseCode {
     ALREADY_CORRECT(HttpStatus.BAD_REQUEST, "이미 정답을 맞췄습니다."),
     //카테고리가 없음
     NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리가 없습니다."),
+    //난이도 없음
+    NOT_FOUND_DIFFICULTY(HttpStatus.NOT_FOUND, "난이도가 없습니다."),
+    //퀴즈 처리 중 문제 발생
+    QUIZ_PROCESSING_ERROR(HttpStatus.BAD_REQUEST, "퀴즈 처리 중 문제가 발생했습니다."),
+    //퀴즈 점수가 없음
+    NOT_FOUND_QUIZ_SCORE(HttpStatus.NOT_FOUND, "퀴즈 점수를 찾을 수 없습니다"),
+    //퀴즈 랭킹이 없음
+    NOT_FOUND_QUIZ_SCORE_RANKING(HttpStatus.NOT_FOUND, "랭킹을 찾을 수 없습니다."),
 
     /**
      * Algorithm Error


### PR DESCRIPTION
## 변경 사항

- **퀴즈 정답 확인 시 점수 시스템 추가**  
  - 사용자가 정답을 맞출 때마다 점수를 부여하는 기능 추가  
  - `QuizScore` 엔티티를 사용하여 사용자별 점수 저장 및 갱신  
  - 난이도(EASY, MEDIUM, HARD)에 따른 차등 점수 부여  
  - 점수 계산 로직을 별도 메서드로 분리하여 가독성 및 유지보수성 향상  

- **퀴즈 및 랭킹 관련 예외 코드 추가**  
  - `NOT_FOUND_DIFFICULTY`: 난이도 없음  
  - `QUIZ_PROCESSING_ERROR`: 퀴즈 처리 중 문제 발생  
  - `NOT_FOUND_QUIZ_SCORE`: 퀴즈 점수 없음  
  - `NOT_FOUND_QUIZ_SCORE_RANKING`: 퀴즈 랭킹 없음  

- **퀴즈 점수 및 랭킹 조회 API 추가**  
  - `/score` 엔드포인트: 사용자의 퀴즈 점수 조회  
  - `/rankings` 엔드포인트: 상위 6명의 퀴즈 랭킹 조회  

- **퀴즈 랭킹 관련 엔티티 및 DTO 추가**  
  - `QuizRanking` 엔티티: 사용자 랭킹 정보를 저장 (예외 처리 포함)  
  - `QuizRankingResponses`: 불변 리스트로 랭킹 응답 관리 (정적 팩토리 메서드 `of()` 제공)  
  - `QuizRankingResponse` DTO: 사용자 순위, 이름, 점수를 포함하며 Swagger의 `@Schema` 어노테이션 적용  
  - `QuizRankings` 엔티티: `QuizRanking` 리스트 관리, 불변 리스트 및 정적 팩토리 메서드 사용  

- **퀴즈 점수 관리 기능 추가**  
  - `QuizScore` 엔티티: 사용자와 1:1 관계로 점수를 관리, 기본 값 0, `incrementScore()` 메서드 구현  
  - `QuizScoreRepository`: 상위 6명의 점수를 조회하는 `findTop6ByOrderByScoreDesc()` 메서드 추가  
  - `QuizScoreResponse` DTO: 사용자 닉네임과 점수를 포함하는 응답 객체 (`from()` 정적 메서드로 변환 지원)  

- **퀴즈 점수 서비스 및 랭킹 조회 기능 추가**  
  - `findQuizScoreById` 메서드: 사용자의 점수 조회  
  - `getTop6Ranking` 메서드: 상위 6명의 랭킹 조회  
  - 사용자 존재 여부 및 퀴즈 점수 유무 확인 후 예외 처리 (`NOT_FOUND_USER`, `NOT_FOUND_QUIZ_SCORE`)  
  - 랭킹 데이터를 `QuizRanking` 객체로 변환하여 `QuizRankings`에 래핑하여 반환  

- **버그 수정**  
  - 사용자가 이미 푼 문제를 제외하지 못하는 버그 수정  
  - `@AuthenticationPrincipal`를 통해 사용자 Email 기준으로 올바르게 조회하도록 변경  

## 참고 사항

- 관련 이슈: [#211](https://github.com/your-repo/issues/211)
- Swagger 문서 업데이트로 API 명세를 최신화했습니다.